### PR TITLE
Rename namespace to lib f fmpeg

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         config: [ {os: windows-latest, copyCommand: copy, artifactName: ffmpegTestWindows, buildPath: Release/, dummyLib: dummyLib.dll, ffmpegTest: ffmpegTest.exe},
                   {os: ubuntu-latest, copyCommand: cp, artifactName: ffmpegTestUbuntu, buildPath: , dummyLib: libdummyLib.so, ffmpegTest: ffmpegTest},
-                  {os: macos-latest, copyCommand: cp, artifactName: ffmpegTestMacIntel, buildPath: , dummyLib: libdummyLib.dylib, ffmpegTest: ffmpegTest},
+                  {os: macos-13, copyCommand: cp, artifactName: ffmpegTestMacIntel, buildPath: , dummyLib: libdummyLib.dylib, ffmpegTest: ffmpegTest},
                   {os: macos-14, copyCommand: cp, artifactName: ffmpegTestMacM1, buildPath: , dummyLib: libdummyLib.dylib, ffmpegTest: ffmpegTest} ]
     runs-on: ${{ matrix.config.os }}
     
@@ -42,7 +42,7 @@ jobs:
       matrix:
         config: [ {os: windows-latest, artifactName: ffmpegTestWindows, azureFolder: windows, unzipCommand: 7z x },
                   {os: ubuntu-latest, artifactName: ffmpegTestUbuntu, azureFolder: ubuntu-22.04, unzipCommand: unzip },
-                  {os: macos-latest, artifactName: ffmpegTestMacIntel, azureFolder: macos-intel, unzipCommand: unzip },
+                  {os: macos-13, artifactName: ffmpegTestMacIntel, azureFolder: macos-intel, unzipCommand: unzip },
                   {os: macos-14, artifactName: ffmpegTestMacM1, azureFolder: macos-m1, unzipCommand: unzip } ]
         ffmpegVersions: ["2.8.22", "3.4.13", "4.4.4", "5.1.4", "6.1.1", "7.0"]
     runs-on: ${{ matrix.config.os }}
@@ -71,7 +71,7 @@ jobs:
       matrix:
         config: [ {os: windows-latest, artifactName: ffmpegTestWindows},
                   {os: ubuntu-latest, artifactName: ffmpegTestUbuntu},
-                  {os: macos-latest, artifactName: ffmpegTestMacIntel},
+                  {os: macos-13, artifactName: ffmpegTestMacIntel},
                   {os: macos-14, artifactName: ffmpegTestMacM1} ]
     runs-on: ${{ matrix.config.os }}
     steps:

--- a/src/app/FileProber.cpp
+++ b/src/app/FileProber.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <sstream>
 
-using namespace ffmpeg;
+using namespace libffmpeg;
 
 const auto FILE_NAME = std::string("testFile.webm");
 
@@ -61,7 +61,7 @@ struct Settings
 {
   bool                  showPackets{};
   std::filesystem::path libraryPath{};
-  ffmpeg::LogLevel      logLevel{ffmpeg::LogLevel::Error};
+  libffmpeg::LogLevel   logLevel{libffmpeg::LogLevel::Error};
 };
 
 Settings parseCommandLineArguments(int argc, char const *argv[])
@@ -73,11 +73,11 @@ Settings parseCommandLineArguments(int argc, char const *argv[])
     if (argument == "-showAllPackets")
       settings.showPackets = true;
     if (argument == "-loglevelDebug")
-      settings.logLevel = ffmpeg::LogLevel::Debug;
+      settings.logLevel = libffmpeg::LogLevel::Debug;
     if (argument == "-loglevelInfo")
-      settings.logLevel = ffmpeg::LogLevel::Info;
+      settings.logLevel = libffmpeg::LogLevel::Info;
     if (argument == "-loglevelWarning")
-      settings.logLevel = ffmpeg::LogLevel::Warning;
+      settings.logLevel = libffmpeg::LogLevel::Warning;
     if (argument == "-libPath")
     {
       i++;

--- a/src/lib/AVCodec/wrappers/AVCodecContextWrapper.cpp
+++ b/src/lib/AVCodec/wrappers/AVCodecContextWrapper.cpp
@@ -13,22 +13,22 @@
 #include "AVCodecContextWrapperInternal.h"
 #include "CastCodecClasses.h"
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
-using ffmpeg::internal::AVCodecContext;
-using ffmpeg::internal::AVCodecID;
-using ffmpeg::internal::AVColorSpace;
-using ffmpeg::internal::AVDictionary;
-using ffmpeg::internal::AVMediaType;
-using ffmpeg::internal::AVPixelFormat;
-using ffmpeg::internal::AVRational;
-using ffmpeg::internal::avcodec::AVCodecContext_56;
-using ffmpeg::internal::avcodec::AVCodecContext_57;
-using ffmpeg::internal::avcodec::AVCodecContext_58;
-using ffmpeg::internal::avcodec::AVCodecContext_59;
-using ffmpeg::internal::avcodec::AVCodecContext_60;
-using ffmpeg::internal::avcodec::AVCodecContext_61;
+using libffmpeg::internal::AVCodecContext;
+using libffmpeg::internal::AVCodecID;
+using libffmpeg::internal::AVColorSpace;
+using libffmpeg::internal::AVDictionary;
+using libffmpeg::internal::AVMediaType;
+using libffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVRational;
+using libffmpeg::internal::avcodec::AVCodecContext_56;
+using libffmpeg::internal::avcodec::AVCodecContext_57;
+using libffmpeg::internal::avcodec::AVCodecContext_58;
+using libffmpeg::internal::avcodec::AVCodecContext_59;
+using libffmpeg::internal::avcodec::AVCodecContext_60;
+using libffmpeg::internal::avcodec::AVCodecContext_61;
 
 namespace internal
 {
@@ -227,4 +227,4 @@ ByteVector AVCodecContextWrapper::getExtradata() const
   return copyDataFromRawArray(extradata, extradataSize);
 }
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecContextWrapper.h
+++ b/src/lib/AVCodec/wrappers/AVCodecContextWrapper.h
@@ -15,7 +15,7 @@
 #include <common/Error.h>
 #include <libHandling/IFFmpegLibraries.h>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 class AVCodecContextWrapper
@@ -23,8 +23,8 @@ class AVCodecContextWrapper
 public:
   AVCodecContextWrapper() = delete;
   AVCodecContextWrapper(std::shared_ptr<IFFmpegLibraries> ffmpegLibraries);
-  AVCodecContextWrapper(ffmpeg::internal::AVCodecContext *codecContext,
-                        std::shared_ptr<IFFmpegLibraries> ffmpegLibraries);
+  AVCodecContextWrapper(libffmpeg::internal::AVCodecContext *codecContext,
+                        std::shared_ptr<IFFmpegLibraries>    ffmpegLibraries);
   AVCodecContextWrapper(const AVCodecContextWrapper &) = delete;
   AVCodecContextWrapper &operator                      =(AVCodecContextWrapper &&);
   AVCodecContextWrapper &operator=(const AVCodecContextWrapper &) = delete;
@@ -47,13 +47,13 @@ public:
   // This is the old FFMpeg 2 interface before pushPacket/pullFrame.
   DecodeResult decodeVideo2(const avcodec::AVPacketWrapper &packet);
 
-  avutil::MediaType             getCodecType() const;
-  ffmpeg::internal::AVCodecID   getCodecID() const;
-  avutil::PixelFormatDescriptor getPixelFormat() const;
-  Size                          getSize() const;
-  avutil::ColorSpace            getColorspace() const;
-  Rational                      getTimeBase() const;
-  ByteVector                    getExtradata() const;
+  avutil::MediaType              getCodecType() const;
+  libffmpeg::internal::AVCodecID getCodecID() const;
+  avutil::PixelFormatDescriptor  getPixelFormat() const;
+  Size                           getSize() const;
+  avutil::ColorSpace             getColorspace() const;
+  Rational                       getTimeBase() const;
+  ByteVector                     getExtradata() const;
 
 private:
   /* It depends on how the wrapper is created who has ownership of this.
@@ -62,10 +62,10 @@ private:
    * for older FFmpeg versions where the AVStream has ownership of the codec. In newer versions,
    * this is not the case anymore.
    */
-  ffmpeg::internal::AVCodecContext *codecContext{};
-  bool                              codecContextOwnership{};
+  libffmpeg::internal::AVCodecContext *codecContext{};
+  bool                                 codecContextOwnership{};
 
   std::shared_ptr<IFFmpegLibraries> ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecContextWrapperInternal.h
+++ b/src/lib/AVCodec/wrappers/AVCodecContextWrapperInternal.h
@@ -8,7 +8,7 @@
 
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avcodec
+namespace libffmpeg::internal::avcodec
 {
 
 struct AVCodecContext_56
@@ -17,21 +17,21 @@ struct AVCodecContext_56
   int            log_level_offset{};
 
   AVMediaType      codec_type{};
-  const AVCodec   *codec{};
+  const AVCodec *  codec{};
   char             codec_name[32]{};
   AVCodecID        codec_id{};
   unsigned int     codec_tag{};
   unsigned int     stream_codec_tag{};
-  void            *priv_data{};
+  void *           priv_data{};
   AVCodecInternal *internal{};
-  void            *opaque{};
+  void *           opaque{};
   int              bit_rate{};
   int              bit_rate_tolerance{};
   int              global_quality{};
   int              compression_level{};
   int              flags{};
   int              flags2{};
-  uint8_t         *extradata{};
+  uint8_t *        extradata{};
   int              extradata_size{};
   AVRational       time_base{};
   int              ticks_per_frame{};
@@ -42,7 +42,7 @@ struct AVCodecContext_56
   AVPixelFormat    pix_fmt{};
   int              me_method{};
   void (*draw_horiz_band)(AVCodecContext *s,
-                          const AVFrame  *src,
+                          const AVFrame * src,
                           int             offset[AV_NUM_DATA_POINTERS],
                           int             y,
                           int             type,
@@ -64,7 +64,7 @@ struct AVCodecContext_56
   float                         dark_masking{};
   int                           slice_count{};
   int                           prediction_method{};
-  int                          *slice_offset{};
+  int *                         slice_offset{};
   AVRational                    sample_aspect_ratio{};
   int                           me_cmp{};
   int                           me_sub_cmp{};
@@ -83,8 +83,8 @@ struct AVCodecContext_56
   int                           slice_flags{};
   int                           xvmc_acceleration{};
   int                           mb_decision{};
-  uint16_t                     *intra_matrix{};
-  uint16_t                     *inter_matrix{};
+  uint16_t *                    intra_matrix{};
+  uint16_t *                    inter_matrix{};
   int                           scenechange_threshold{};
   int                           noise_reduction{};
   int                           me_threshold{};
@@ -115,24 +115,24 @@ struct AVCodecContext_56
 
 struct AVCodecContext_57
 {
-  const AVClass   *av_class{};
+  const AVClass *  av_class{};
   int              log_level_offset{};
   AVMediaType      codec_type{};
-  const AVCodec   *codec{};
+  const AVCodec *  codec{};
   char             codec_name[32]{};
   AVCodecID        codec_id{};
   unsigned int     codec_tag{};
   unsigned int     stream_codec_tag{};
-  void            *priv_data{};
+  void *           priv_data{};
   AVCodecInternal *internal{};
-  void            *opaque{};
+  void *           opaque{};
   int64_t          bit_rate{};
   int              bit_rate_tolerance{};
   int              global_quality{};
   int              compression_level{};
   int              flags{};
   int              flags2{};
-  uint8_t         *extradata{};
+  uint8_t *        extradata{};
   int              extradata_size{};
   AVRational       time_base{};
   int              ticks_per_frame{};
@@ -143,7 +143,7 @@ struct AVCodecContext_57
   AVPixelFormat    pix_fmt{};
   int              me_method{};
   void (*draw_horiz_band)(AVCodecContext *s,
-                          const AVFrame  *src,
+                          const AVFrame * src,
                           int             offset[AV_NUM_DATA_POINTERS],
                           int             y,
                           int             type,
@@ -165,7 +165,7 @@ struct AVCodecContext_57
   float                         dark_masking{};
   int                           slice_count{};
   int                           prediction_method{};
-  int                          *slice_offset{};
+  int *                         slice_offset{};
   AVRational                    sample_aspect_ratio{};
   int                           me_cmp{};
   int                           me_sub_cmp{};
@@ -184,8 +184,8 @@ struct AVCodecContext_57
   int                           slice_flags{};
   int                           xvmc_acceleration{};
   int                           mb_decision{};
-  uint16_t                     *intra_matrix{};
-  uint16_t                     *inter_matrix{};
+  uint16_t *                    intra_matrix{};
+  uint16_t *                    inter_matrix{};
   int                           scenechange_threshold{};
   int                           noise_reduction{};
   int                           me_threshold{};
@@ -216,22 +216,22 @@ struct AVCodecContext_57
 
 struct AVCodecContext_58
 {
-  const AVClass   *av_class{};
+  const AVClass *  av_class{};
   int              log_level_offset{};
   AVMediaType      codec_type{};
-  const AVCodec   *codec{};
+  const AVCodec *  codec{};
   AVCodecID        codec_id{};
   unsigned int     codec_tag{};
-  void            *priv_data{};
+  void *           priv_data{};
   AVCodecInternal *internal{};
-  void            *opaque{};
+  void *           opaque{};
   int64_t          bit_rate{};
   int              bit_rate_tolerance{};
   int              global_quality{};
   int              compression_level{};
   int              flags{};
   int              flags2{};
-  uint8_t         *extradata{};
+  uint8_t *        extradata{};
   int              extradata_size{};
   AVRational       time_base{};
   int              ticks_per_frame{};
@@ -241,7 +241,7 @@ struct AVCodecContext_58
   int              gop_size{};
   AVPixelFormat    pix_fmt{};
   void (*draw_horiz_band)(AVCodecContext *s,
-                          const AVFrame  *src,
+                          const AVFrame * src,
                           int             offset[AV_NUM_DATA_POINTERS],
                           int             y,
                           int             type,
@@ -262,7 +262,7 @@ struct AVCodecContext_58
   float                         dark_masking{};
   int                           slice_count{};
   int                           prediction_method{};
-  int                          *slice_offset{};
+  int *                         slice_offset{};
   AVRational                    sample_aspect_ratio{};
   int                           me_cmp{};
   int                           me_sub_cmp{};
@@ -277,8 +277,8 @@ struct AVCodecContext_58
   int                           me_range{};
   int                           slice_flags{};
   int                           mb_decision{};
-  uint16_t                     *intra_matrix{};
-  uint16_t                     *inter_matrix{};
+  uint16_t *                    intra_matrix{};
+  uint16_t *                    inter_matrix{};
   int                           scenechange_threshold{};
   int                           noise_reduction{};
   int                           intra_dc_precision{};
@@ -306,22 +306,22 @@ struct AVCodecContext_58
 
 struct AVCodecContext_59
 {
-  const AVClass   *av_class{};
+  const AVClass *  av_class{};
   int              log_level_offset{};
   AVMediaType      codec_type{};
-  const AVCodec   *codec{};
+  const AVCodec *  codec{};
   AVCodecID        codec_id{};
   unsigned int     codec_tag{};
-  void            *priv_data{};
+  void *           priv_data{};
   AVCodecInternal *internal{};
-  void            *opaque{};
+  void *           opaque{};
   int64_t          bit_rate{};
   int              bit_rate_tolerance{};
   int              global_quality{};
   int              compression_level{};
   int              flags{};
   int              flags2{};
-  uint8_t         *extradata{};
+  uint8_t *        extradata{};
   int              extradata_size{};
   AVRational       time_base{};
   int              ticks_per_frame{};
@@ -331,7 +331,7 @@ struct AVCodecContext_59
   int              gop_size{};
   AVPixelFormat    pix_fmt{};
   void (*draw_horiz_band)(AVCodecContext *s,
-                          const AVFrame  *src,
+                          const AVFrame * src,
                           int             offset[AV_NUM_DATA_POINTERS],
                           int             y,
                           int             type,
@@ -349,7 +349,7 @@ struct AVCodecContext_59
   float                         p_masking{};
   float                         dark_masking{};
   int                           slice_count{};
-  int                          *slice_offset{};
+  int *                         slice_offset{};
   AVRational                    sample_aspect_ratio{};
   int                           me_cmp{};
   int                           me_sub_cmp{};
@@ -363,8 +363,8 @@ struct AVCodecContext_59
   int                           me_range{};
   int                           slice_flags{};
   int                           mb_decision{};
-  uint16_t                     *intra_matrix{};
-  uint16_t                     *inter_matrix{};
+  uint16_t *                    intra_matrix{};
+  uint16_t *                    inter_matrix{};
   int                           intra_dc_precision{};
   int                           skip_top{};
   int                           skip_bottom{};
@@ -388,19 +388,19 @@ typedef AVCodecContext_59 AVCodecContext_60;
 
 struct AVCodecContext_61
 {
-  const AVClass                     *av_class{};
+  const AVClass *                    av_class{};
   int                                log_level_offset{};
   AVMediaType                        codec_type{};
-  const AVCodec                     *codec{};
+  const AVCodec *                    codec{};
   AVCodecID                          codec_id{};
   unsigned int                       codec_tag{};
-  void                              *priv_data{};
-  AVCodecInternal                   *internal{};
-  void                              *opaque{};
+  void *                             priv_data{};
+  AVCodecInternal *                  internal{};
+  void *                             opaque{};
   int64_t                            bit_rate;
   int                                flags;
   int                                flags2;
-  uint8_t                           *extradata;
+  uint8_t *                          extradata;
   int                                extradata_size;
   AVRational                         time_base;
   AVRational                         pkt_timebase;
@@ -422,7 +422,7 @@ struct AVCodecContext_61
   int                                has_b_frames;
   int                                slice_flags;
   void (*draw_horiz_band)(struct AVCodecContext *s,
-                          const AVFrame         *src,
+                          const AVFrame *        src,
                           int                    offset[AV_NUM_DATA_POINTERS],
                           int                    y,
                           int                    type,
@@ -432,4 +432,4 @@ struct AVCodecContext_61
   // Actually, there is more here, but the variables above are the only we need.
 };
 
-} // namespace ffmpeg::internal::avcodec
+} // namespace libffmpeg::internal::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecDescriptorConversion.cpp
+++ b/src/lib/AVCodec/wrappers/AVCodecDescriptorConversion.cpp
@@ -11,16 +11,16 @@
 #include "AVCodecDescriptorConversionInternal.h"
 #include "CastCodecClasses.h"
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVCodecDescriptor;
-using ffmpeg::internal::avcodec::AVCodecDescriptor_56;
-using ffmpeg::internal::avcodec::AVCodecDescriptor_57;
-using ffmpeg::internal::avcodec::AVProfile_57;
+using libffmpeg::internal::AVCodecDescriptor;
+using libffmpeg::internal::avcodec::AVCodecDescriptor_56;
+using libffmpeg::internal::avcodec::AVCodecDescriptor_57;
+using libffmpeg::internal::avcodec::AVProfile_57;
 
 constexpr auto AV_CODEC_PROP_INTRA_ONLY = (1 << 0);
 constexpr auto AV_CODEC_PROP_LOSSY      = (1 << 1);
@@ -83,7 +83,7 @@ std::vector<std::string> parseProfiles(const struct AVProfile_57 *profiles)
 }
 
 CodecDescriptor convertAVCodecDescriptor(const internal::AVCodecDescriptor *avCodecDescriptor,
-                                         const Version                     &avCodecVersion)
+                                         const Version &                    avCodecVersion)
 {
   if (avCodecDescriptor == nullptr)
     throw std::runtime_error("Invalid avCodecDescriptor given");
@@ -93,7 +93,7 @@ CodecDescriptor convertAVCodecDescriptor(const internal::AVCodecDescriptor *avCo
   if (avCodecVersion.major == 56)
   {
     const auto p          = reinterpret_cast<const AVCodecDescriptor_56 *>(avCodecDescriptor);
-    descriptor.mediaType  = ffmpeg::avutil::toMediaType(p->type);
+    descriptor.mediaType  = libffmpeg::avutil::toMediaType(p->type);
     descriptor.codecName  = std::string(p->name);
     descriptor.longName   = std::string(p->long_name);
     descriptor.properties = parseProperties(p->props);
@@ -102,7 +102,7 @@ CodecDescriptor convertAVCodecDescriptor(const internal::AVCodecDescriptor *avCo
   else
   {
     const auto p          = reinterpret_cast<const AVCodecDescriptor_57 *>(avCodecDescriptor);
-    descriptor.mediaType  = ffmpeg::avutil::toMediaType(p->type);
+    descriptor.mediaType  = libffmpeg::avutil::toMediaType(p->type);
     descriptor.codecName  = std::string(p->name);
     descriptor.longName   = std::string(p->long_name);
     descriptor.properties = parseProperties(p->props);
@@ -113,4 +113,4 @@ CodecDescriptor convertAVCodecDescriptor(const internal::AVCodecDescriptor *avCo
   return descriptor;
 }
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecDescriptorConversion.h
+++ b/src/lib/AVCodec/wrappers/AVCodecDescriptorConversion.h
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 struct CodecDescriptorProperties
@@ -37,6 +37,6 @@ struct CodecDescriptor
 bool operator==(const CodecDescriptorProperties &lhs, const CodecDescriptorProperties &rhs);
 
 CodecDescriptor convertAVCodecDescriptor(const internal::AVCodecDescriptor *avCodecDescriptor,
-                                         const Version                     &avCodecVersion);
+                                         const Version &                    avCodecVersion);
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecDescriptorConversionInternal.h
+++ b/src/lib/AVCodec/wrappers/AVCodecDescriptorConversionInternal.h
@@ -8,7 +8,7 @@
 
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avcodec
+namespace libffmpeg::internal::avcodec
 {
 
 struct AVProfile_57
@@ -25,8 +25,8 @@ struct AVCodecDescriptor_56
 {
   AVCodecID          id;
   AVMediaType        type;
-  const char        *name;
-  const char        *long_name;
+  const char *       name;
+  const char *       long_name;
   int                props;
   const char *const *mime_types;
 };
@@ -35,10 +35,10 @@ struct AVCodecDescriptor_57
 {
   AVCodecID                  id;
   AVMediaType                type;
-  const char                *name;
-  const char                *long_name;
+  const char *               name;
+  const char *               long_name;
   int                        props;
-  const char *const         *mime_types;
+  const char *const *        mime_types;
   const struct AVProfile_57 *profiles;
 };
 
@@ -47,4 +47,4 @@ typedef AVCodecDescriptor_57 AVCodecDescriptor_59;
 typedef AVCodecDescriptor_57 AVCodecDescriptor_60;
 typedef AVCodecDescriptor_57 AVCodecDescriptor_61;
 
-} // namespace ffmpeg::internal::avcodec
+} // namespace libffmpeg::internal::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecParametersWrapper.cpp
+++ b/src/lib/AVCodec/wrappers/AVCodecParametersWrapper.cpp
@@ -14,22 +14,22 @@
 
 #include <cstring>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVCodecID;
-using ffmpeg::internal::AVCodecParameters;
-using ffmpeg::internal::AVMediaType;
-using ffmpeg::internal::AVRational;
-using ffmpeg::internal::avcodec::AVCodecParameters_56;
-using ffmpeg::internal::avcodec::AVCodecParameters_57;
-using ffmpeg::internal::avcodec::AVCodecParameters_58;
-using ffmpeg::internal::avcodec::AVCodecParameters_59;
-using ffmpeg::internal::avcodec::AVCodecParameters_60;
-using ffmpeg::internal::avcodec::AVCodecParameters_61;
+using libffmpeg::internal::AVCodecID;
+using libffmpeg::internal::AVCodecParameters;
+using libffmpeg::internal::AVMediaType;
+using libffmpeg::internal::AVRational;
+using libffmpeg::internal::avcodec::AVCodecParameters_56;
+using libffmpeg::internal::avcodec::AVCodecParameters_57;
+using libffmpeg::internal::avcodec::AVCodecParameters_58;
+using libffmpeg::internal::avcodec::AVCodecParameters_59;
+using libffmpeg::internal::avcodec::AVCodecParameters_60;
+using libffmpeg::internal::avcodec::AVCodecParameters_61;
 
 constexpr std::size_t AV_INPUT_BUFFER_PADDING_SIZE = 32;
 
@@ -57,12 +57,12 @@ avutil::MediaType AVCodecParametersWrapper::getCodecType() const
 
   AVMediaType mediaType;
   CAST_AVCODEC_GET_MEMBER(AVCodecParameters, this->codecParameters, mediaType, codec_type);
-  return ffmpeg::avutil::toMediaType(mediaType);
+  return libffmpeg::avutil::toMediaType(mediaType);
 }
 
 AVCodecID AVCodecParametersWrapper::getCodecID() const
 {
-  RETURN_IF_VERSION_TOO_OLD(ffmpeg::internal::AV_CODEC_ID_NONE);
+  RETURN_IF_VERSION_TOO_OLD(libffmpeg::internal::AV_CODEC_ID_NONE);
 
   AVCodecID codecID;
   CAST_AVCODEC_GET_MEMBER(AVCodecParameters, this->codecParameters, codecID, codec_id);
@@ -132,8 +132,8 @@ void AVCodecParametersWrapper::setClearValues()
   if (version == 57 || version == 58 || version == 59 || version == 60 || version == 61)
   {
     auto p                   = reinterpret_cast<AVCodecParameters_57 *>(this->codecParameters);
-    p->codec_type            = ffmpeg::internal::AVMEDIA_TYPE_UNKNOWN;
-    p->codec_id              = ffmpeg::internal::AV_CODEC_ID_NONE;
+    p->codec_type            = libffmpeg::internal::AVMEDIA_TYPE_UNKNOWN;
+    p->codec_id              = libffmpeg::internal::AV_CODEC_ID_NONE;
     p->codec_tag             = 0;
     p->extradata             = nullptr;
     p->extradata_size        = 0;
@@ -166,7 +166,7 @@ void AVCodecParametersWrapper::setClearValues()
 void AVCodecParametersWrapper::setAVMediaType(avutil::MediaType type)
 {
   CAST_AVCODEC_SET_MEMBER(
-      AVCodecParameters, this->codecParameters, codec_type, ffmpeg::avutil::toAVMediaType(type));
+      AVCodecParameters, this->codecParameters, codec_type, libffmpeg::avutil::toAVMediaType(type));
 }
 
 void AVCodecParametersWrapper::setAVCodecID(AVCodecID id)
@@ -176,7 +176,7 @@ void AVCodecParametersWrapper::setAVCodecID(AVCodecID id)
 
 void AVCodecParametersWrapper::setExtradata(const ByteVector &data)
 {
-  uint8_t   *extradata{};
+  uint8_t *  extradata{};
   const auto versions = this->ffmpegLibraries->getLibrariesVersion();
   CAST_AVCODEC_GET_MEMBER(AVCodecParameters, this->codecParameters, extradata, extradata);
 
@@ -224,4 +224,4 @@ void AVCodecParametersWrapper::setSampleAspectRatio(int num, int den)
   CAST_AVCODEC_SET_MEMBER(AVCodecParameters, this->codecParameters, sample_aspect_ratio, ratio);
 }
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecParametersWrapper.h
+++ b/src/lib/AVCodec/wrappers/AVCodecParametersWrapper.h
@@ -13,39 +13,42 @@
 #include <common/Types.h>
 #include <libHandling/IFFmpegLibraries.h>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 class AVCodecParametersWrapper
 {
 public:
   AVCodecParametersWrapper() = delete;
-  AVCodecParametersWrapper(ffmpeg::internal::AVCodecParameters *p,
-                           std::shared_ptr<IFFmpegLibraries>    libraries);
+  AVCodecParametersWrapper(libffmpeg::internal::AVCodecParameters *p,
+                           std::shared_ptr<IFFmpegLibraries>       libraries);
 
-  avutil::MediaType             getCodecType() const;
-  ffmpeg::internal::AVCodecID   getCodecID() const;
-  ByteVector                    getExtradata() const;
-  Size                          getSize() const;
-  avutil::ColorSpace            getColorspace() const;
-  avutil::PixelFormatDescriptor getPixelFormat() const;
-  Rational                      getSampleAspectRatio() const;
+  avutil::MediaType              getCodecType() const;
+  libffmpeg::internal::AVCodecID getCodecID() const;
+  ByteVector                     getExtradata() const;
+  Size                           getSize() const;
+  avutil::ColorSpace             getColorspace() const;
+  avutil::PixelFormatDescriptor  getPixelFormat() const;
+  Rational                       getSampleAspectRatio() const;
 
   // Set a default set of (unknown) values
   void setClearValues();
 
   void setAVMediaType(avutil::MediaType type);
-  void setAVCodecID(ffmpeg::internal::AVCodecID id);
+  void setAVCodecID(libffmpeg::internal::AVCodecID id);
   void setExtradata(const ByteVector &extradata);
   void setSize(Size size);
   void setAVPixelFormat(avutil::PixelFormatDescriptor descriptor);
   void setProfileLevel(int profile, int level);
   void setSampleAspectRatio(int num, int den);
 
-  ffmpeg::internal::AVCodecParameters *getCodecParameters() const { return this->codecParameters; }
+  libffmpeg::internal::AVCodecParameters *getCodecParameters() const
+  {
+    return this->codecParameters;
+  }
 
 private:
-  ffmpeg::internal::AVCodecParameters *codecParameters{};
-  std::shared_ptr<IFFmpegLibraries>    ffmpegLibraries;
+  libffmpeg::internal::AVCodecParameters *codecParameters{};
+  std::shared_ptr<IFFmpegLibraries>       ffmpegLibraries;
 };
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecParametersWrapperInternal.h
+++ b/src/lib/AVCodec/wrappers/AVCodecParametersWrapperInternal.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-namespace ffmpeg::internal::avcodec
+namespace libffmpeg::internal::avcodec
 {
 
 /* In avcodec version 56, this struct does not exist yet.
@@ -18,7 +18,7 @@ struct AVCodecParameters_56
 {
   AVMediaType  codec_type;
   AVCodecID    codec_id;
-  uint8_t     *extradata;
+  uint8_t *    extradata;
   int          extradata_size;
   int          format;
   int          profile;
@@ -34,7 +34,7 @@ struct AVCodecParameters_57
   AVMediaType                   codec_type;
   AVCodecID                     codec_id;
   uint32_t                      codec_tag;
-  uint8_t                      *extradata;
+  uint8_t *                     extradata;
   int                           extradata_size;
   int                           format;
   int64_t                       bit_rate;
@@ -65,9 +65,9 @@ struct AVCodecParameters_61
   AVMediaType                   codec_type;
   AVCodecID                     codec_id;
   uint32_t                      codec_tag;
-  uint8_t                      *extradata;
+  uint8_t *                     extradata;
   int                           extradata_size;
-  AVPacketSideData             *coded_side_data;
+  AVPacketSideData *            coded_side_data;
   int                           nb_coded_side_data;
   int                           format;
   int64_t                       bit_rate;
@@ -90,4 +90,4 @@ struct AVCodecParameters_61
   // Actually, there is more here, but the variables above are the only we need.
 };
 
-} // namespace ffmpeg::internal::avcodec
+} // namespace libffmpeg::internal::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecWrapper.cpp
+++ b/src/lib/AVCodec/wrappers/AVCodecWrapper.cpp
@@ -13,21 +13,21 @@
 #include "AVCodecWrapperInternal.h"
 #include "CastCodecClasses.h"
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
-using ffmpeg::internal::AVCodec;
-using ffmpeg::internal::AVCodecID;
-using ffmpeg::internal::AVMediaType;
-using ffmpeg::internal::AVPixelFormat;
-using ffmpeg::internal::AVRational;
-using ffmpeg::internal::AVSampleFormat;
-using ffmpeg::internal::avcodec::AVCodec_56;
-using ffmpeg::internal::avcodec::AVCodec_57;
-using ffmpeg::internal::avcodec::AVCodec_58;
-using ffmpeg::internal::avcodec::AVCodec_59;
-using ffmpeg::internal::avcodec::AVCodec_60;
-using ffmpeg::internal::avcodec::AVCodec_61;
+using libffmpeg::internal::AVCodec;
+using libffmpeg::internal::AVCodecID;
+using libffmpeg::internal::AVMediaType;
+using libffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVRational;
+using libffmpeg::internal::AVSampleFormat;
+using libffmpeg::internal::avcodec::AVCodec_56;
+using libffmpeg::internal::avcodec::AVCodec_57;
+using libffmpeg::internal::avcodec::AVCodec_58;
+using libffmpeg::internal::avcodec::AVCodec_59;
+using libffmpeg::internal::avcodec::AVCodec_60;
+using libffmpeg::internal::avcodec::AVCodec_61;
 
 namespace
 {
@@ -74,7 +74,7 @@ avutil::MediaType AVCodecWrapper::getMediaType() const
 {
   AVMediaType mediaType;
   CAST_AVCODEC_GET_MEMBER(AVCodec, this->codec, mediaType, type);
-  return ffmpeg::avutil::toMediaType(mediaType);
+  return libffmpeg::avutil::toMediaType(mediaType);
 }
 
 AVCodecID AVCodecWrapper::getCodecID() const
@@ -154,4 +154,4 @@ uint8_t AVCodecWrapper::getMaxLowres() const
   return maxLowres;
 }
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecWrapper.h
+++ b/src/lib/AVCodec/wrappers/AVCodecWrapper.h
@@ -13,34 +13,34 @@
 #include <memory>
 #include <vector>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 class AVCodecWrapper
 {
 public:
   AVCodecWrapper() = delete;
-  AVCodecWrapper(ffmpeg::internal::AVCodec        *codec,
+  AVCodecWrapper(libffmpeg::internal::AVCodec *    codec,
                  std::shared_ptr<IFFmpegLibraries> ffmpegLibraries);
 
-  explicit                   operator bool() const { return this->codec != nullptr; }
-  ffmpeg::internal::AVCodec *getAVCodec() const { return this->codec; }
+  explicit                      operator bool() const { return this->codec != nullptr; }
+  libffmpeg::internal::AVCodec *getAVCodec() const { return this->codec; }
 
-  std::string                                   getName() const;
-  std::string                                   getLongName() const;
-  avutil::MediaType                             getMediaType() const;
-  ffmpeg::internal::AVCodecID                   getCodecID() const;
-  int                                           getCapabilities() const;
-  std::vector<Rational>                         getSupportedFramerates() const;
-  std::vector<avutil::PixelFormatDescriptor>    getPixelFormats() const;
-  std::vector<int>                              getSupportedSamplerates() const;
-  std::vector<ffmpeg::internal::AVSampleFormat> getSampleFormats() const;
-  std::vector<uint64_t>                         getChannelLayouts() const;
-  uint8_t                                       getMaxLowres() const;
+  std::string                                      getName() const;
+  std::string                                      getLongName() const;
+  avutil::MediaType                                getMediaType() const;
+  libffmpeg::internal::AVCodecID                   getCodecID() const;
+  int                                              getCapabilities() const;
+  std::vector<Rational>                            getSupportedFramerates() const;
+  std::vector<avutil::PixelFormatDescriptor>       getPixelFormats() const;
+  std::vector<int>                                 getSupportedSamplerates() const;
+  std::vector<libffmpeg::internal::AVSampleFormat> getSampleFormats() const;
+  std::vector<uint64_t>                            getChannelLayouts() const;
+  uint8_t                                          getMaxLowres() const;
 
 private:
-  ffmpeg::internal::AVCodec        *codec{};
+  libffmpeg::internal::AVCodec *    codec{};
   std::shared_ptr<IFFmpegLibraries> ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVCodecWrapperInternal.h
+++ b/src/lib/AVCodec/wrappers/AVCodecWrapperInternal.h
@@ -8,23 +8,23 @@
 
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avcodec
+namespace libffmpeg::internal::avcodec
 {
 
 struct AVCodec_56
 {
-  const char           *name;
-  const char           *long_name;
+  const char *          name;
+  const char *          long_name;
   AVMediaType           type;
   AVCodecID             id;
   int                   capabilities;
-  const AVRational     *supported_framerates;
-  const AVPixelFormat  *pix_fmts;
-  const int            *supported_samplerates;
+  const AVRational *    supported_framerates;
+  const AVPixelFormat * pix_fmts;
+  const int *           supported_samplerates;
   const AVSampleFormat *sample_fmts;
-  const uint64_t       *channel_layouts;
+  const uint64_t *      channel_layouts;
   uint8_t               max_lowres;
-  const AVClass        *priv_class;
+  const AVClass *       priv_class;
 
   // Actually, there is more here, but nothing more of the public API
 };
@@ -34,18 +34,18 @@ typedef AVCodec_56 AVCodec_58;
 
 struct AVCodec_59
 {
-  const char           *name;
-  const char           *long_name;
+  const char *          name;
+  const char *          long_name;
   AVMediaType           type;
   AVCodecID             id;
   int                   capabilities;
   uint8_t               max_lowres;
-  const AVRational     *supported_framerates;
-  const AVPixelFormat  *pix_fmts;
-  const int            *supported_samplerates;
+  const AVRational *    supported_framerates;
+  const AVPixelFormat * pix_fmts;
+  const int *           supported_samplerates;
   const AVSampleFormat *sample_fmts;
-  const uint64_t       *channel_layouts;
-  const AVClass        *priv_class;
+  const uint64_t *      channel_layouts;
+  const AVClass *       priv_class;
 
   // Actually, there is more here, but nothing more of the public API
 };
@@ -54,20 +54,20 @@ typedef AVCodec_59 AVCodec_60;
 
 struct AVCodec_61
 {
-  const char           *name;
-  const char           *long_name;
+  const char *          name;
+  const char *          long_name;
   AVMediaType           type;
   AVCodecID             id;
   int                   capabilities;
   uint8_t               max_lowres;
-  const AVRational     *supported_framerates;
-  const AVPixelFormat  *pix_fmts;
-  const int            *supported_samplerates;
+  const AVRational *    supported_framerates;
+  const AVPixelFormat * pix_fmts;
+  const int *           supported_samplerates;
   const AVSampleFormat *sample_fmts;
-  const AVClass        *priv_class;
-  const AVProfile      *profiles;
-  const char           *wrapper_name;
-  const uint64_t       *channel_layouts;
+  const AVClass *       priv_class;
+  const AVProfile *     profiles;
+  const char *          wrapper_name;
+  const uint64_t *      channel_layouts;
 };
 
-} // namespace ffmpeg::internal::avcodec
+} // namespace libffmpeg::internal::avcodec

--- a/src/lib/AVCodec/wrappers/AVPacketWrapper.cpp
+++ b/src/lib/AVCodec/wrappers/AVPacketWrapper.cpp
@@ -13,19 +13,19 @@
 
 #include <cstring>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVPacket;
-using ffmpeg::internal::avcodec::AVPacket_56;
-using ffmpeg::internal::avcodec::AVPacket_57;
-using ffmpeg::internal::avcodec::AVPacket_58;
-using ffmpeg::internal::avcodec::AVPacket_59;
-using ffmpeg::internal::avcodec::AVPacket_60;
-using ffmpeg::internal::avcodec::AVPacket_61;
+using libffmpeg::internal::AVPacket;
+using libffmpeg::internal::avcodec::AVPacket_56;
+using libffmpeg::internal::avcodec::AVPacket_57;
+using libffmpeg::internal::avcodec::AVPacket_58;
+using libffmpeg::internal::avcodec::AVPacket_59;
+using libffmpeg::internal::avcodec::AVPacket_60;
+using libffmpeg::internal::avcodec::AVPacket_61;
 
 constexpr auto AV_PKT_FLAG_KEY     = 0x0001; ///< The packet contains a keyframe
 constexpr auto AV_PKT_FLAG_CORRUPT = 0x0002; ///< The packet content is corrupted
@@ -41,7 +41,7 @@ AVPacketWrapper::AVPacketWrapper(std::shared_ptr<IFFmpegLibraries> ffmpegLibrari
   this->allocateNewPacket();
 }
 
-AVPacketWrapper::AVPacketWrapper(const ByteVector                 &data,
+AVPacketWrapper::AVPacketWrapper(const ByteVector &                data,
                                  std::shared_ptr<IFFmpegLibraries> ffmpegLibraries)
     : ffmpegLibraries(ffmpegLibraries)
 {
@@ -181,4 +181,4 @@ void AVPacketWrapper::AVPacketDeleter::operator()(AVPacket *packet) const noexce
     this->ffmpegLibraries->avcodec.av_packet_free(&packet);
 }
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVPacketWrapper.h
+++ b/src/lib/AVCodec/wrappers/AVPacketWrapper.h
@@ -10,7 +10,7 @@
 
 #include <memory>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 class AVPacketWrapper
@@ -26,7 +26,7 @@ public:
 
   void setTimestamps(const int64_t dts, const int64_t pts);
 
-  ffmpeg::internal::AVPacket *getPacket() const { return this->packet.get(); }
+  libffmpeg::internal::AVPacket *getPacket() const { return this->packet.get(); }
 
   struct Flags
   {
@@ -54,14 +54,15 @@ private:
     AVPacketDeleter() = default;
     AVPacketDeleter(const std::shared_ptr<IFFmpegLibraries> &ffmpegLibraries)
         : ffmpegLibraries(ffmpegLibraries){};
-    void operator()(ffmpeg::internal::AVPacket *packet) const noexcept;
+    void operator()(libffmpeg::internal::AVPacket *packet) const noexcept;
 
   private:
     std::shared_ptr<IFFmpegLibraries> ffmpegLibraries{};
   };
 
-  std::unique_ptr<ffmpeg::internal::AVPacket, AVPacketDeleter> packet{nullptr, AVPacketDeleter()};
-  std::shared_ptr<IFFmpegLibraries>                            ffmpegLibraries{};
+  std::unique_ptr<libffmpeg::internal::AVPacket, AVPacketDeleter> packet{nullptr,
+                                                                         AVPacketDeleter()};
+  std::shared_ptr<IFFmpegLibraries>                               ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/src/lib/AVCodec/wrappers/AVPacketWrapperInternal.h
+++ b/src/lib/AVCodec/wrappers/AVPacketWrapperInternal.h
@@ -8,7 +8,7 @@
 
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avcodec
+namespace libffmpeg::internal::avcodec
 {
 
 // AVPacket is part of avcodec. The definition is different for different major versions of avcodec.
@@ -17,10 +17,10 @@ namespace ffmpeg::internal::avcodec
 // since its size is used in other structures (e.g. AVStream).
 struct AVPacket_56
 {
-  AVBufferRef      *buf;
+  AVBufferRef *     buf;
   int64_t           pts;
   int64_t           dts;
-  uint8_t          *data;
+  uint8_t *         data;
   int               size;
   int               stream_index;
   int               flags;
@@ -28,17 +28,17 @@ struct AVPacket_56
   int               side_data_elems;
   int               duration;
   void (*destruct)(AVPacket *);
-  void   *priv;
+  void *  priv;
   int64_t pos;
   int64_t convergence_duration;
 };
 
 struct AVPacket_57
 {
-  AVBufferRef      *buf;
+  AVBufferRef *     buf;
   int64_t           pts;
   int64_t           dts;
-  uint8_t          *data;
+  uint8_t *         data;
   int               size;
   int               stream_index;
   int               flags;
@@ -53,10 +53,10 @@ typedef AVPacket_57 AVPacket_58;
 
 struct AVPacket_59
 {
-  AVBufferRef      *buf;
+  AVBufferRef *     buf;
   int64_t           pts;
   int64_t           dts;
-  uint8_t          *data;
+  uint8_t *         data;
   int               size;
   int               stream_index;
   int               flags;
@@ -64,12 +64,12 @@ struct AVPacket_59
   int               side_data_elems;
   int64_t           duration;
   int64_t           pos;
-  void             *opaque;
-  AVBufferRef      *opaque_ref;
+  void *            opaque;
+  AVBufferRef *     opaque_ref;
   AVRational        time_base;
 };
 
 typedef AVPacket_59 AVPacket_60;
 typedef AVPacket_59 AVPacket_61;
 
-} // namespace ffmpeg::internal::avcodec
+} // namespace libffmpeg::internal::avcodec

--- a/src/lib/AVFormat/wrappers/AVFormatContextWrapper.cpp
+++ b/src/lib/AVFormat/wrappers/AVFormatContextWrapper.cpp
@@ -10,18 +10,18 @@
 
 #include "CastFormatClasses.h"
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
-using ffmpeg::internal::AVDictionary;
-using ffmpeg::internal::AVInputFormat;
-using ffmpeg::internal::AVStream;
-using ffmpeg::internal::avformat::AVFormatContext_56;
-using ffmpeg::internal::avformat::AVFormatContext_57;
-using ffmpeg::internal::avformat::AVFormatContext_58;
-using ffmpeg::internal::avformat::AVFormatContext_59;
-using ffmpeg::internal::avformat::AVFormatContext_60;
-using ffmpeg::internal::avformat::AVFormatContext_61;
+using libffmpeg::internal::AVDictionary;
+using libffmpeg::internal::AVInputFormat;
+using libffmpeg::internal::AVStream;
+using libffmpeg::internal::avformat::AVFormatContext_56;
+using libffmpeg::internal::avformat::AVFormatContext_57;
+using libffmpeg::internal::avformat::AVFormatContext_58;
+using libffmpeg::internal::avformat::AVFormatContext_59;
+using libffmpeg::internal::avformat::AVFormatContext_60;
+using libffmpeg::internal::avformat::AVFormatContext_61;
 
 AVFormatContextWrapper::AVFormatContextWrapper(std::shared_ptr<IFFmpegLibraries> ffmpegLibraries)
 {
@@ -139,4 +139,4 @@ bool AVFormatContextWrapper::getNextPacket(avcodec::AVPacketWrapper &packet)
   return ret == 0;
 }
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/src/lib/AVFormat/wrappers/AVFormatContextWrapper.h
+++ b/src/lib/AVFormat/wrappers/AVFormatContextWrapper.h
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 class AVFormatContextWrapper
@@ -41,8 +41,8 @@ public:
   bool getNextPacket(avcodec::AVPacketWrapper &packet);
 
 private:
-  ffmpeg::internal::AVFormatContext *formatContext{nullptr};
-  std::shared_ptr<IFFmpegLibraries>  ffmpegLibraries{};
+  libffmpeg::internal::AVFormatContext *formatContext{nullptr};
+  std::shared_ptr<IFFmpegLibraries>     ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/src/lib/AVFormat/wrappers/AVFormatContextWrapperInternal.h
+++ b/src/lib/AVFormat/wrappers/AVFormatContextWrapperInternal.h
@@ -8,56 +8,56 @@
 
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avformat
+namespace libffmpeg::internal::avformat
 {
 
 // AVFormatContext is part of avformat.
 // These functions give us version independent access to the structs.
 struct AVFormatContext_56
 {
-  const AVClass  *av_class;
-  AVInputFormat  *iformat;
+  const AVClass * av_class;
+  AVInputFormat * iformat;
   AVOutputFormat *oformat;
-  void           *priv_data;
-  AVIOContext    *pb;
+  void *          priv_data;
+  AVIOContext *   pb;
   int             ctx_flags;
-  unsigned int    nb_streams; //
-  AVStream      **streams;    //
+  unsigned int    nb_streams;
+  AVStream **     streams;
   char            filename[1024];
   int64_t         start_time;
-  int64_t         duration; //
+  int64_t         duration;
   int             bit_rate;
   unsigned int    packet_size;
   int             max_delay;
   int             flags;
   unsigned int    probesize;
   int             max_analyze_duration;
-  const uint8_t  *key;
+  const uint8_t * key;
   int             keylen;
   unsigned int    nb_programs;
-  AVProgram     **programs;
+  AVProgram **    programs;
   AVCodecID       video_codec_id;
   AVCodecID       audio_codec_id;
   AVCodecID       subtitle_codec_id;
   unsigned int    max_index_size;
   unsigned int    max_picture_buffer;
   unsigned int    nb_chapters;
-  AVChapter     **chapters;
-  AVDictionary   *metadata;
+  AVChapter **    chapters;
+  AVDictionary *  metadata;
 
   // Actually, there is more here, but the variables above are the only we need.
 };
 
 struct AVFormatContext_57
 {
-  const AVClass  *av_class;
-  AVInputFormat  *iformat;
+  const AVClass * av_class;
+  AVInputFormat * iformat;
   AVOutputFormat *oformat;
-  void           *priv_data;
-  AVIOContext    *pb;
+  void *          priv_data;
+  AVIOContext *   pb;
   int             ctx_flags;
   unsigned int    nb_streams;
-  AVStream      **streams;
+  AVStream **     streams;
   char            filename[1024];
   int64_t         start_time;
   int64_t         duration;
@@ -67,34 +67,34 @@ struct AVFormatContext_57
   int             flags;
   int64_t         probesize;
   int64_t         max_analyze_duration;
-  const uint8_t  *key;
+  const uint8_t * key;
   int             keylen;
   unsigned int    nb_programs;
-  AVProgram     **programs;
+  AVProgram **    programs;
   AVCodecID       video_codec_id;
   AVCodecID       audio_codec_id;
   AVCodecID       subtitle_codec_id;
   unsigned int    max_index_size;
   unsigned int    max_picture_buffer;
   unsigned int    nb_chapters;
-  AVChapter     **chapters;
-  AVDictionary   *metadata;
+  AVChapter **    chapters;
+  AVDictionary *  metadata;
 
   // Actually, there is more here, but the variables above are the only we need.
 };
 
 struct AVFormatContext_58
 {
-  const AVClass  *av_class;
-  AVInputFormat  *iformat;
+  const AVClass * av_class;
+  AVInputFormat * iformat;
   AVOutputFormat *oformat;
-  void           *priv_data;
-  AVIOContext    *pb;
+  void *          priv_data;
+  AVIOContext *   pb;
   int             ctx_flags;
   unsigned int    nb_streams;
-  AVStream      **streams;
+  AVStream **     streams;
   char            filename[1024];
-  char           *url;
+  char *          url;
   int64_t         start_time;
   int64_t         duration;
   int64_t         bit_rate;
@@ -103,33 +103,33 @@ struct AVFormatContext_58
   int             flags;
   int64_t         probesize;
   int64_t         max_analyze_duration;
-  const uint8_t  *key;
+  const uint8_t * key;
   int             keylen;
   unsigned int    nb_programs;
-  AVProgram     **programs;
+  AVProgram **    programs;
   AVCodecID       video_codec_id;
   AVCodecID       audio_codec_id;
   AVCodecID       subtitle_codec_id;
   unsigned int    max_index_size;
   unsigned int    max_picture_buffer;
   unsigned int    nb_chapters;
-  AVChapter     **chapters;
-  AVDictionary   *metadata;
+  AVChapter **    chapters;
+  AVDictionary *  metadata;
 
   // Actually, there is more here, but the variables above are the only we need.
 };
 
 struct AVFormatContext_59
 {
-  const AVClass  *av_class;
-  AVInputFormat  *iformat;
+  const AVClass * av_class;
+  AVInputFormat * iformat;
   AVOutputFormat *oformat;
-  void           *priv_data;
-  AVIOContext    *pb;
+  void *          priv_data;
+  AVIOContext *   pb;
   int             ctx_flags;
   unsigned int    nb_streams;
-  AVStream      **streams;
-  char           *url;
+  AVStream **     streams;
+  char *          url;
   int64_t         start_time;
   int64_t         duration;
   int64_t         bit_rate;
@@ -138,18 +138,18 @@ struct AVFormatContext_59
   int             flags;
   int64_t         probesize;
   int64_t         max_analyze_duration;
-  const uint8_t  *key;
+  const uint8_t * key;
   int             keylen;
   unsigned int    nb_programs;
-  AVProgram     **programs;
+  AVProgram **    programs;
   AVCodecID       video_codec_id;
   AVCodecID       audio_codec_id;
   AVCodecID       subtitle_codec_id;
   unsigned int    max_index_size;
   unsigned int    max_picture_buffer;
   unsigned int    nb_chapters;
-  AVChapter     **chapters;
-  AVDictionary   *metadata;
+  AVChapter **    chapters;
+  AVDictionary *  metadata;
 
   // Actually, there is more here, but the variables above are the only we need.
 };
@@ -158,19 +158,19 @@ typedef AVFormatContext_59 AVFormatContext_60;
 
 struct AVFormatContext_61
 {
-  const AVClass  *av_class;
-  AVInputFormat  *iformat;
+  const AVClass * av_class;
+  AVInputFormat * iformat;
   AVOutputFormat *oformat;
-  void           *priv_data;
-  AVIOContext    *pb;
+  void *          priv_data;
+  AVIOContext *   pb;
   int             ctx_flags;
   unsigned int    nb_streams;
-  AVStream      **streams;
+  AVStream **     streams;
   unsigned int    nb_stream_groups; // Added in 61
   AVStreamGroup **stream_groups;    // Added in 61
   unsigned int    nb_chapters;      // Moved in 61
-  AVChapter     **chapters;         // Moved in 61
-  char           *url;
+  AVChapter **    chapters;         // Moved in 61
+  char *          url;
   int64_t         start_time;
   int64_t         duration;
   int64_t         bit_rate;
@@ -179,17 +179,17 @@ struct AVFormatContext_61
   int             flags;
   int64_t         probesize;
   int64_t         max_analyze_duration;
-  const uint8_t  *key;
+  const uint8_t * key;
   int             keylen;
   unsigned int    nb_programs;
-  AVProgram     **programs;
+  AVProgram **    programs;
   AVCodecID       video_codec_id;
   AVCodecID       audio_codec_id;
   AVCodecID       subtitle_codec_id;
   AVCodecID       data_codec_id; // Added in 61
-  AVDictionary   *metadata;      // Moved in 61
+  AVDictionary *  metadata;      // Moved in 61
 
   // Actually, there is more here, but the variables above are the only we need.
 };
 
-} // namespace ffmpeg::internal::avformat
+} // namespace libffmpeg::internal::avformat

--- a/src/lib/AVFormat/wrappers/AVInputFormatWrapper.cpp
+++ b/src/lib/AVFormat/wrappers/AVInputFormatWrapper.cpp
@@ -13,19 +13,19 @@
 
 #include <sstream>
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVInputFormat;
-using ffmpeg::internal::avformat::AVInputFormat_56;
-using ffmpeg::internal::avformat::AVInputFormat_57;
-using ffmpeg::internal::avformat::AVInputFormat_58;
-using ffmpeg::internal::avformat::AVInputFormat_59;
-using ffmpeg::internal::avformat::AVInputFormat_60;
-using ffmpeg::internal::avformat::AVInputFormat_61;
+using libffmpeg::internal::AVInputFormat;
+using libffmpeg::internal::avformat::AVInputFormat_56;
+using libffmpeg::internal::avformat::AVInputFormat_57;
+using libffmpeg::internal::avformat::AVInputFormat_58;
+using libffmpeg::internal::avformat::AVInputFormat_59;
+using libffmpeg::internal::avformat::AVInputFormat_60;
+using libffmpeg::internal::avformat::AVInputFormat_61;
 
 } // namespace
 
@@ -87,7 +87,7 @@ bool operator==(const AVInputFormatFlags &lhs, const AVInputFormatFlags &rhs)
           lhs.tsNegative == rhs.tsNegative && lhs.seekToPTS == rhs.seekToPTS);
 }
 
-AVInputFormatWrapper::AVInputFormatWrapper(AVInputFormat                    *inputFormat,
+AVInputFormatWrapper::AVInputFormatWrapper(AVInputFormat *                   inputFormat,
                                            std::shared_ptr<IFFmpegLibraries> ffmpegLibraries)
     : inputFormat(inputFormat), ffmpegLibraries(ffmpegLibraries)
 {
@@ -152,4 +152,4 @@ std::string AVInputFormatWrapper::getMimeType() const
   return mimeTypeCStr == nullptr ? "" : std::string(mimeTypeCStr);
 }
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/src/lib/AVFormat/wrappers/AVInputFormatWrapper.h
+++ b/src/lib/AVFormat/wrappers/AVInputFormatWrapper.h
@@ -8,7 +8,7 @@
 
 #include <libHandling/IFFmpegLibraries.h>
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 struct AVInputFormatFlags
@@ -40,8 +40,8 @@ class AVInputFormatWrapper
 {
 public:
   AVInputFormatWrapper() = delete;
-  AVInputFormatWrapper(ffmpeg::internal::AVInputFormat  *inputFormat,
-                       std::shared_ptr<IFFmpegLibraries> ffmpegLibraries);
+  AVInputFormatWrapper(libffmpeg::internal::AVInputFormat *inputFormat,
+                       std::shared_ptr<IFFmpegLibraries>   ffmpegLibraries);
 
   std::string        getName() const;
   std::string        getLongName() const;
@@ -52,8 +52,8 @@ public:
   explicit operator bool() const { return this->inputFormat != nullptr; };
 
 private:
-  ffmpeg::internal::AVInputFormat  *inputFormat{};
-  std::shared_ptr<IFFmpegLibraries> ffmpegLibraries{};
+  libffmpeg::internal::AVInputFormat *inputFormat{};
+  std::shared_ptr<IFFmpegLibraries>   ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/src/lib/AVFormat/wrappers/AVInputFormatWrapperInternal.h
+++ b/src/lib/AVFormat/wrappers/AVInputFormatWrapperInternal.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-namespace ffmpeg::internal::avformat
+namespace libffmpeg::internal::avformat
 {
 
 constexpr auto AVFMT_NOFILE        = 0x0001;
@@ -30,13 +30,13 @@ constexpr auto AVFMT_SEEK_TO_PTS   = 0x4000000;
 
 struct AVInputFormat_56
 {
-  const char                     *name;
-  const char                     *long_name;
+  const char *                    name;
+  const char *                    long_name;
   int                             flags;
-  const char                     *extensions;
+  const char *                    extensions;
   const struct AVCodecTag *const *codec_tag;
-  const AVClass                  *priv_class;
-  const char                     *mime_type;
+  const AVClass *                 priv_class;
+  const char *                    mime_type;
 
   // There is more but it is not part of the public ABI
 };
@@ -47,4 +47,4 @@ typedef AVInputFormat_56 AVInputFormat_59;
 typedef AVInputFormat_56 AVInputFormat_60;
 typedef AVInputFormat_56 AVInputFormat_61;
 
-} // namespace ffmpeg::internal::avformat
+} // namespace libffmpeg::internal::avformat

--- a/src/lib/AVFormat/wrappers/AVStreamWrapper.cpp
+++ b/src/lib/AVFormat/wrappers/AVStreamWrapper.cpp
@@ -11,28 +11,28 @@
 #include "AVStreamWrapperInternal.h"
 #include "CastFormatClasses.h"
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVCodecContext;
-using ffmpeg::internal::AVCodecID;
-using ffmpeg::internal::AVCodecParameters;
-using ffmpeg::internal::AVRational;
-using ffmpeg::internal::AVStream;
-using ffmpeg::internal::AVStreamParseType;
-using ffmpeg::internal::avformat::AVStream_56;
-using ffmpeg::internal::avformat::AVStream_57;
-using ffmpeg::internal::avformat::AVStream_58;
-using ffmpeg::internal::avformat::AVStream_59;
-using ffmpeg::internal::avformat::AVStream_60;
-using ffmpeg::internal::avformat::AVStream_61;
+using libffmpeg::internal::AVCodecContext;
+using libffmpeg::internal::AVCodecID;
+using libffmpeg::internal::AVCodecParameters;
+using libffmpeg::internal::AVRational;
+using libffmpeg::internal::AVStream;
+using libffmpeg::internal::AVStreamParseType;
+using libffmpeg::internal::avformat::AVStream_56;
+using libffmpeg::internal::avformat::AVStream_57;
+using libffmpeg::internal::avformat::AVStream_58;
+using libffmpeg::internal::avformat::AVStream_59;
+using libffmpeg::internal::avformat::AVStream_60;
+using libffmpeg::internal::avformat::AVStream_61;
 
 } // namespace
 
-AVStreamWrapper::AVStreamWrapper(AVStream                         *stream,
+AVStreamWrapper::AVStreamWrapper(AVStream *                        stream,
                                  std::shared_ptr<IFFmpegLibraries> ffmpegLibraries)
     : stream(stream), ffmpegLibraries(ffmpegLibraries)
 {
@@ -68,7 +68,7 @@ AVCodecID AVStreamWrapper::getCodecID() const
   if (const auto codecContext = this->getCodecContext())
     return codecContext->getCodecID();
 
-  return ffmpeg::internal::AV_CODEC_ID_NONE;
+  return libffmpeg::internal::AV_CODEC_ID_NONE;
 }
 
 Rational AVStreamWrapper::getAverageFrameRate() const
@@ -211,4 +211,4 @@ std::optional<avcodec::AVCodecParametersWrapper> AVStreamWrapper::getCodecParame
   return {};
 }
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/src/lib/AVFormat/wrappers/AVStreamWrapper.h
+++ b/src/lib/AVFormat/wrappers/AVStreamWrapper.h
@@ -15,35 +15,35 @@
 
 #include <memory>
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 class AVStreamWrapper
 {
 public:
   AVStreamWrapper() = delete;
-  AVStreamWrapper(ffmpeg::internal::AVStream       *stream,
+  AVStreamWrapper(libffmpeg::internal::AVStream *   stream,
                   std::shared_ptr<IFFmpegLibraries> ffmpegLibraries);
 
   explicit operator bool() const { return this->stream != nullptr; };
 
-  int                           getIndex() const;
-  avutil::MediaType             getCodecType() const;
-  ffmpeg::internal::AVCodecID   getCodecID() const;
-  Rational                      getAverageFrameRate() const;
-  Rational                      getTimeBase() const;
-  Size                          getFrameSize() const;
-  avutil::ColorSpace            getColorspace() const;
-  avutil::PixelFormatDescriptor getPixelFormat() const;
-  ByteVector                    getExtradata() const;
+  int                            getIndex() const;
+  avutil::MediaType              getCodecType() const;
+  libffmpeg::internal::AVCodecID getCodecID() const;
+  Rational                       getAverageFrameRate() const;
+  Rational                       getTimeBase() const;
+  Size                           getFrameSize() const;
+  avutil::ColorSpace             getColorspace() const;
+  avutil::PixelFormatDescriptor  getPixelFormat() const;
+  ByteVector                     getExtradata() const;
 
   std::optional<avcodec::CodecDescriptor>          getCodecDescriptor() const;
   std::optional<avcodec::AVCodecParametersWrapper> getCodecParameters() const;
   std::optional<avcodec::AVCodecContextWrapper>    getCodecContext() const;
 
 private:
-  ffmpeg::internal::AVStream       *stream{};
+  libffmpeg::internal::AVStream *   stream{};
   std::shared_ptr<IFFmpegLibraries> ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/src/lib/AVFormat/wrappers/AVStreamWrapperInternal.h
+++ b/src/lib/AVFormat/wrappers/AVStreamWrapperInternal.h
@@ -9,7 +9,7 @@
 #include <AVCodec/wrappers/AVPacketWrapperInternal.h>
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avformat
+namespace libffmpeg::internal::avformat
 {
 
 class AVIndexEntry;
@@ -20,8 +20,8 @@ struct AVStream_56
 {
   int                  index{};
   int                  id{};
-  AVCodecContext      *codec{};
-  void                *priv_data{};
+  AVCodecContext *     codec{};
+  void *               priv_data{};
   AVFrac               pts{};
   AVRational           time_base{};
   int64_t              start_time{};
@@ -30,28 +30,28 @@ struct AVStream_56
   int                  disposition{};
   AVDiscard            discard{};
   AVRational           sample_aspect_ratio{};
-  AVDictionary        *metadata{};
+  AVDictionary *       metadata{};
   AVRational           avg_frame_rate{};
   avcodec::AVPacket_56 attached_pic{};
-  AVPacketSideData    *side_data{};
+  AVPacketSideData *   side_data{};
   int                  nb_side_data{};
   int                  event_flags{};
 };
 
 struct AVProbeData_57
 {
-  const char    *filename{};
+  const char *   filename{};
   unsigned char *buf{};
   int            buf_size{};
-  const char    *mime_type{};
+  const char *   mime_type{};
 };
 
 struct AVStream_57
 {
   int                  index{};
   int                  id{};
-  AVCodecContext      *codec{}; // Deprecated.
-  void                *priv_data{};
+  AVCodecContext *     codec{}; // Deprecated.
+  void *               priv_data{};
   AVFrac               pts{}; // Deprecated.
   AVRational           time_base{};
   int64_t              start_time{};
@@ -60,10 +60,10 @@ struct AVStream_57
   int                  disposition{};
   AVDiscard            discard{};
   AVRational           sample_aspect_ratio{};
-  AVDictionary        *metadata{};
+  AVDictionary *       metadata{};
   AVRational           avg_frame_rate{};
   avcodec::AVPacket_57 attached_pic{};
-  AVPacketSideData    *side_data{};
+  AVPacketSideData *   side_data{};
   int                  nb_side_data{};
   int                  event_flags{};
   // All field following this line are not part of the public API and may change/be removed.
@@ -95,7 +95,7 @@ struct AVStream_57
   int                          codec_info_nb_frames{};
   AVStreamParseType            need_parsing{};
   struct AVCodecParserContext *parser{};
-  struct AVPacketList         *last_in_packet_buffer{};
+  struct AVPacketList *        last_in_packet_buffer{};
   AVProbeData_57               probe_data{};
 #define MAX_REORDER_DELAY 16
   int64_t       pts_buffer[MAX_REORDER_DELAY + 1]{};
@@ -125,10 +125,10 @@ struct AVStream_57
   int           inject_global_side_data{};
   // All fields above this line are not part of the public API.
   // All fields below are part of the public API and ABI again.
-  char              *recommended_encoder_configuration{};
+  char *             recommended_encoder_configuration{};
   AVRational         display_aspect_ratio{};
-  struct FFFrac     *priv_pts{};
-  AVStreamInternal  *internal{};
+  struct FFFrac *    priv_pts{};
+  AVStreamInternal * internal{};
   AVCodecParameters *codecpar{};
 };
 
@@ -136,8 +136,8 @@ struct AVStream_58
 {
   int                  index{};
   int                  id{};
-  AVCodecContext      *codec{};
-  void                *priv_data{};
+  AVCodecContext *     codec{};
+  void *               priv_data{};
   AVRational           time_base{};
   int64_t              start_time{};
   int64_t              duration{};
@@ -145,15 +145,15 @@ struct AVStream_58
   int                  disposition{};
   AVDiscard            discard{};
   AVRational           sample_aspect_ratio{};
-  AVDictionary        *metadata{};
+  AVDictionary *       metadata{};
   AVRational           avg_frame_rate{};
   avcodec::AVPacket_58 attached_pic{};
-  AVPacketSideData    *side_data{};
+  AVPacketSideData *   side_data{};
   int                  nb_side_data{};
   int                  event_flags{};
   AVRational           r_frame_rate{};
-  char                *recommended_encoder_configuration{};
-  AVCodecParameters   *codecpar{};
+  char *               recommended_encoder_configuration{};
+  AVCodecParameters *  codecpar{};
 
   // All field following this line are not part of the public API and may change/be removed.
 };
@@ -162,7 +162,7 @@ struct AVStream_59
 {
   int                  index{};
   int                  id{};
-  void                *priv_data{};
+  void *               priv_data{};
   AVRational           time_base{};
   int64_t              start_time{};
   int64_t              duration{};
@@ -170,24 +170,24 @@ struct AVStream_59
   int                  disposition{};
   AVDiscard            discard{};
   AVRational           sample_aspect_ratio{};
-  AVDictionary        *metadata{};
+  AVDictionary *       metadata{};
   AVRational           avg_frame_rate{};
   avcodec::AVPacket_59 attached_pic{};
-  AVPacketSideData    *side_data{};
+  AVPacketSideData *   side_data{};
   int                  nb_side_data{};
   int                  event_flags{};
   AVRational           r_frame_rate{};
-  AVCodecParameters   *codecpar{};
+  AVCodecParameters *  codecpar{};
   int                  pts_wrap_bits{};
 };
 
 struct AVStream_60
 {
-  const AVClass       *av_class{};
+  const AVClass *      av_class{};
   int                  index{};
   int                  id{};
-  AVCodecParameters   *codecpar{};
-  void                *priv_data{};
+  AVCodecParameters *  codecpar{};
+  void *               priv_data{};
   AVRational           time_base{};
   int64_t              start_time{};
   int64_t              duration{};
@@ -195,10 +195,10 @@ struct AVStream_60
   int                  disposition{};
   AVDiscard            discard{};
   AVRational           sample_aspect_ratio{};
-  AVDictionary        *metadata{};
+  AVDictionary *       metadata{};
   AVRational           avg_frame_rate{};
   avcodec::AVPacket_60 attached_pic{};
-  AVPacketSideData    *side_data{};
+  AVPacketSideData *   side_data{};
   int                  nb_side_data{};
   int                  event_flags{};
   AVRational           r_frame_rate{};
@@ -207,4 +207,4 @@ struct AVStream_60
 
 typedef AVStream_60 AVStream_61;
 
-} // namespace ffmpeg::internal::avformat
+} // namespace libffmpeg::internal::avformat

--- a/src/lib/AVUtil/ColorSpace.cpp
+++ b/src/lib/AVUtil/ColorSpace.cpp
@@ -6,10 +6,10 @@
 
 #include "ColorSpace.h"
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
-using ffmpeg::internal::AVColorSpace;
+using libffmpeg::internal::AVColorSpace;
 
 ColorSpace toColorspace(const AVColorSpace colorspace)
 {
@@ -51,4 +51,4 @@ ColorSpace toColorspace(const AVColorSpace colorspace)
   }
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/ColorSpace.h
+++ b/src/lib/AVUtil/ColorSpace.h
@@ -9,7 +9,7 @@
 #include <common/EnumMapper.h>
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 enum class ColorSpace
@@ -58,6 +58,6 @@ const EnumMapper<ColorSpace> colorSpaceMapper(
       "Chromaticity-derived constant luminance system"},
      {ColorSpace::ICTCP, "Unspecified", "ITU-R BT.2100-0, ICtCp"}});
 
-ColorSpace toColorspace(const ffmpeg::internal::AVColorSpace colorspace);
+ColorSpace toColorspace(const libffmpeg::internal::AVColorSpace colorspace);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/MediaType.cpp
+++ b/src/lib/AVUtil/MediaType.cpp
@@ -6,10 +6,10 @@
 
 #include "MediaType.h"
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
-using ffmpeg::internal::AVMediaType;
+using libffmpeg::internal::AVMediaType;
 
 MediaType toMediaType(const AVMediaType mediaType)
 {
@@ -53,4 +53,4 @@ AVMediaType toAVMediaType(const MediaType mediaType)
   }
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/MediaType.h
+++ b/src/lib/AVUtil/MediaType.h
@@ -9,7 +9,7 @@
 #include <common/EnumMapper.h>
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 enum class MediaType
@@ -29,7 +29,7 @@ const EnumMapper<MediaType> mediaTypeMapper({{MediaType::Unknown, "Unknown"},
                                              {MediaType::Subtitle, "Subtitle"},
                                              {MediaType::Attachment, "Attachment"}});
 
-MediaType                     toMediaType(const ffmpeg::internal::AVMediaType mediaType);
-ffmpeg::internal::AVMediaType toAVMediaType(const MediaType mediaType);
+MediaType                        toMediaType(const libffmpeg::internal::AVMediaType mediaType);
+libffmpeg::internal::AVMediaType toAVMediaType(const MediaType mediaType);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/PictureType.cpp
+++ b/src/lib/AVUtil/PictureType.cpp
@@ -6,10 +6,10 @@
 
 #include "PictureType.h"
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
-using ffmpeg::internal::AVPictureType;
+using libffmpeg::internal::AVPictureType;
 
 PictureType toPictureType(const AVPictureType pictureType)
 {
@@ -36,4 +36,4 @@ PictureType toPictureType(const AVPictureType pictureType)
   }
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/PictureType.h
+++ b/src/lib/AVUtil/PictureType.h
@@ -9,7 +9,7 @@
 #include <common/EnumMapper.h>
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 enum class PictureType
@@ -34,6 +34,6 @@ const EnumMapper<PictureType>
                        {PictureType::SP, "SP-Frame", "Switching predictively coded frame"},
                        {PictureType::SI, "SI-Frame", "Switching bi-predictively coded frame"}});
 
-PictureType toPictureType(const ffmpeg::internal::AVPictureType pictureType);
+PictureType toPictureType(const libffmpeg::internal::AVPictureType pictureType);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVDictionaryWrapper.cpp
+++ b/src/lib/AVUtil/wrappers/AVDictionaryWrapper.cpp
@@ -6,11 +6,11 @@
 
 #include "AVDictionaryWrapper.h"
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
-using ffmpeg::internal::AVDictionary;
-using ffmpeg::internal::AVDictionaryEntry;
+using libffmpeg::internal::AVDictionary;
+using libffmpeg::internal::AVDictionaryEntry;
 
 constexpr auto AV_DICT_IGNORE_SUFFIX = 2;
 
@@ -46,4 +46,4 @@ DictionaryMap AVDictionaryWrapper::toMap() const
   return map;
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVDictionaryWrapper.h
+++ b/src/lib/AVUtil/wrappers/AVDictionaryWrapper.h
@@ -10,11 +10,11 @@
 
 #include <map>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 using DictionaryMap = std::map<std::string, std::string>;
-using ffmpeg::internal::AVDictionary;
+using libffmpeg::internal::AVDictionary;
 
 class AVDictionaryWrapper
 {
@@ -32,4 +32,4 @@ private:
   std::shared_ptr<IFFmpegLibraries> ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVFrameSideDataWrapper.cpp
+++ b/src/lib/AVUtil/wrappers/AVFrameSideDataWrapper.cpp
@@ -11,14 +11,14 @@
 
 #include <stdexcept>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVFrameSideData;
-using ffmpeg::internal::AVFrameSideDataType;
+using libffmpeg::internal::AVFrameSideData;
+using libffmpeg::internal::AVFrameSideDataType;
 
 } // namespace
 
@@ -38,7 +38,7 @@ std::vector<MotionVector> AVFrameSideDataWrapper::getMotionVectors() const
   AVFrameSideDataType type;
   CAST_AVUTIL_GET_MEMBER(AVFrameSideData, this->sideData, type, type);
 
-  if (type != ffmpeg::internal::AV_FRAME_DATA_MOTION_VECTORS)
+  if (type != libffmpeg::internal::AV_FRAME_DATA_MOTION_VECTORS)
     return {};
 
   uint8_t *data;
@@ -50,4 +50,4 @@ std::vector<MotionVector> AVFrameSideDataWrapper::getMotionVectors() const
   return parseMotionData(this->ffmpegLibraries->getLibrariesVersion(), data, size);
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVFrameSideDataWrapper.h
+++ b/src/lib/AVUtil/wrappers/AVFrameSideDataWrapper.h
@@ -12,23 +12,23 @@
 
 #include <memory>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 class AVFrameSideDataWrapper
 {
 public:
   AVFrameSideDataWrapper() = delete;
-  AVFrameSideDataWrapper(ffmpeg::internal::AVFrameSideData *sideData,
-                         std::shared_ptr<IFFmpegLibraries>  ffmpegLibraries);
+  AVFrameSideDataWrapper(libffmpeg::internal::AVFrameSideData *sideData,
+                         std::shared_ptr<IFFmpegLibraries>     ffmpegLibraries);
 
   std::vector<MotionVector> getMotionVectors() const;
 
   explicit operator bool() const { return sideData != nullptr; }
 
 private:
-  ffmpeg::internal::AVFrameSideData *sideData{};
-  std::shared_ptr<IFFmpegLibraries>  ffmpegLibraries{};
+  libffmpeg::internal::AVFrameSideData *sideData{};
+  std::shared_ptr<IFFmpegLibraries>     ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVFrameSideDataWrapperInternal.h
+++ b/src/lib/AVUtil/wrappers/AVFrameSideDataWrapperInternal.h
@@ -8,16 +8,16 @@
 
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avutil
+namespace libffmpeg::internal::avutil
 {
 
 struct AVFrameSideData_54
 {
   AVFrameSideDataType type;
-  uint8_t            *data;
+  uint8_t *           data;
   int                 size;
-  AVDictionary       *metadata;
-  AVBufferRef        *buf;
+  AVDictionary *      metadata;
+  AVBufferRef *       buf;
 };
 
 typedef AVFrameSideData_54 AVFrameSideData_55;
@@ -26,13 +26,13 @@ typedef AVFrameSideData_54 AVFrameSideData_56;
 struct AVFrameSideData_57
 {
   AVFrameSideDataType type;
-  uint8_t            *data;
+  uint8_t *           data;
   size_t              size;
-  AVDictionary       *metadata;
-  AVBufferRef        *buf;
+  AVDictionary *      metadata;
+  AVBufferRef *       buf;
 };
 
 typedef AVFrameSideData_57 AVFrameSideData_58;
 typedef AVFrameSideData_57 AVFrameSideData_59;
 
-} // namespace ffmpeg::internal::avutil
+} // namespace libffmpeg::internal::avutil

--- a/src/lib/AVUtil/wrappers/AVFrameWrapper.cpp
+++ b/src/lib/AVUtil/wrappers/AVFrameWrapper.cpp
@@ -13,16 +13,16 @@
 
 #include <stdexcept>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVDictionary;
-using ffmpeg::internal::AVFrame;
-using ffmpeg::internal::AVPictureType;
-using ffmpeg::internal::AVRational;
+using libffmpeg::internal::AVDictionary;
+using libffmpeg::internal::AVFrame;
+using libffmpeg::internal::AVPictureType;
+using libffmpeg::internal::AVRational;
 
 ByteVector copyFrameDataFromRawArray(const uint8_t *inputData, Size size, const int linesize)
 {
@@ -125,7 +125,7 @@ avutil::PictureType AVFrameWrapper::getPictType() const
 {
   AVPictureType pictureType;
   CAST_AVUTIL_GET_MEMBER(AVFrame, this->frame.get(), pictureType, pict_type);
-  return ffmpeg::avutil::toPictureType(pictureType);
+  return libffmpeg::avutil::toPictureType(pictureType);
 }
 
 bool AVFrameWrapper::isKeyFrame() const
@@ -154,7 +154,7 @@ PixelFormatDescriptor AVFrameWrapper::getPixelFormatDescriptor() const
   int format;
   CAST_AVUTIL_GET_MEMBER(AVFrame, this->frame.get(), format, format);
 
-  return convertAVPixFmtDescriptor(static_cast<ffmpeg::internal::AVPixelFormat>(format),
+  return convertAVPixFmtDescriptor(static_cast<libffmpeg::internal::AVPixelFormat>(format),
                                    this->ffmpegLibraries);
 }
 
@@ -172,4 +172,4 @@ void AVFrameWrapper::AVFrameDeleter::operator()(AVFrame *frame) const noexcept
     this->ffmpegLibraries->avutil.av_frame_free(&frame);
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVFrameWrapper.h
+++ b/src/lib/AVUtil/wrappers/AVFrameWrapper.h
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 class AVFrameWrapper
@@ -28,7 +28,7 @@ public:
   AVFrameWrapper &operator=(AVFrameWrapper &&);
   AVFrameWrapper &operator=(const AVFrameWrapper &) = delete;
 
-  ffmpeg::internal::AVFrame *getFrame() const { return this->frame.get(); }
+  libffmpeg::internal::AVFrame *getFrame() const { return this->frame.get(); }
 
   ByteVector                         getData(int component) const;
   int                                getLineSize(int component) const;
@@ -49,14 +49,14 @@ private:
     AVFrameDeleter() = default;
     AVFrameDeleter(const std::shared_ptr<IFFmpegLibraries> &ffmpegLibraries)
         : ffmpegLibraries(ffmpegLibraries){};
-    void operator()(ffmpeg::internal::AVFrame *frame) const noexcept;
+    void operator()(libffmpeg::internal::AVFrame *frame) const noexcept;
 
   private:
     std::shared_ptr<IFFmpegLibraries> ffmpegLibraries{};
   };
 
-  std::unique_ptr<ffmpeg::internal::AVFrame, AVFrameDeleter> frame{nullptr, AVFrameDeleter()};
-  std::shared_ptr<IFFmpegLibraries>                          ffmpegLibraries{};
+  std::unique_ptr<libffmpeg::internal::AVFrame, AVFrameDeleter> frame{nullptr, AVFrameDeleter()};
+  std::shared_ptr<IFFmpegLibraries>                             ffmpegLibraries{};
 };
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVFrameWrapperInternal.h
+++ b/src/lib/AVUtil/wrappers/AVFrameWrapperInternal.h
@@ -8,20 +8,20 @@
 
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avutil
+namespace libffmpeg::internal::avutil
 {
 
 struct AVFrame_54
 {
-  uint8_t      *data[AV_NUM_DATA_POINTERS];
+  uint8_t *     data[AV_NUM_DATA_POINTERS];
   int           linesize[AV_NUM_DATA_POINTERS];
-  uint8_t     **extended_data;
+  uint8_t **    extended_data;
   int           width, height;
   int           nb_samples;
   int           format;
   int           key_frame;
   AVPictureType pict_type;
-  uint8_t      *base[AV_NUM_DATA_POINTERS];
+  uint8_t *     base[AV_NUM_DATA_POINTERS];
   AVRational    sample_aspect_ratio;
   int64_t       pts;
   int64_t       pkt_pts;
@@ -34,9 +34,9 @@ struct AVFrame_54
 
 struct AVFrame_55
 {
-  uint8_t      *data[AV_NUM_DATA_POINTERS];
+  uint8_t *     data[AV_NUM_DATA_POINTERS];
   int           linesize[AV_NUM_DATA_POINTERS];
-  uint8_t     **extended_data;
+  uint8_t **    extended_data;
   int           width, height;
   int           nb_samples;
   int           format;
@@ -56,9 +56,9 @@ typedef AVFrame_55 AVFrame_56;
 
 struct AVFrame_57
 {
-  uint8_t                      *data[AV_NUM_DATA_POINTERS];
+  uint8_t *                     data[AV_NUM_DATA_POINTERS];
   int                           linesize[AV_NUM_DATA_POINTERS];
-  uint8_t                     **extended_data;
+  uint8_t **                    extended_data;
   int                           width, height;
   int                           nb_samples;
   int                           format;
@@ -71,7 +71,7 @@ struct AVFrame_57
   int                           coded_picture_number;   // Deprecated
   int                           display_picture_number; // Deprecated
   int                           quality;
-  void                         *opaque;
+  void *                        opaque;
   int                           repeat_pict;
   int                           interlaced_frame;
   int                           top_field_first;
@@ -79,10 +79,10 @@ struct AVFrame_57
   int64_t                       reordered_opaque;
   int                           sample_rate;
   uint64_t                      channel_layout;
-  AVBufferRef                  *buf[AV_NUM_DATA_POINTERS];
-  AVBufferRef                 **extended_buf;
+  AVBufferRef *                 buf[AV_NUM_DATA_POINTERS];
+  AVBufferRef **                extended_buf;
   int                           nb_extended_buf;
-  AVFrameSideData             **side_data;
+  AVFrameSideData **            side_data;
   int                           nb_side_data;
   int                           flags;
   AVColorRange                  color_range;
@@ -93,7 +93,7 @@ struct AVFrame_57
   int64_t                       best_effort_timestamp;
   int64_t                       pkt_pos;
   int64_t                       pkt_duration;
-  AVDictionary                 *metadata;
+  AVDictionary *                metadata;
 
   // Actually, there is more here, but the variables above are the only we need.
 };
@@ -102,9 +102,9 @@ typedef AVFrame_57 AVFrame_58;
 
 struct AVFrame_59
 {
-  uint8_t                      *data[AV_NUM_DATA_POINTERS];
+  uint8_t *                     data[AV_NUM_DATA_POINTERS];
   int                           linesize[AV_NUM_DATA_POINTERS];
-  uint8_t                     **extended_data;
+  uint8_t **                    extended_data;
   int                           width, height;
   int                           nb_samples;
   int                           format;
@@ -115,17 +115,17 @@ struct AVFrame_59
   int64_t                       pkt_dts;
   AVRational                    time_base;
   int                           quality;
-  void                         *opaque;
+  void *                        opaque;
   int                           repeat_pict;
   int                           interlaced_frame;    // Deprecated
   int                           top_field_first;     // Deprecated
   int                           palette_has_changed; // Deprecated
   int64_t                       reordered_opaque;
   int                           sample_rate;
-  AVBufferRef                  *buf[AV_NUM_DATA_POINTERS];
-  AVBufferRef                 **extended_buf;
+  AVBufferRef *                 buf[AV_NUM_DATA_POINTERS];
+  AVBufferRef **                extended_buf;
   int                           nb_extended_buf;
-  AVFrameSideData             **side_data;
+  AVFrameSideData **            side_data;
   int                           nb_side_data;
   int                           flags;
   AVColorRange                  color_range;
@@ -135,9 +135,9 @@ struct AVFrame_59
   AVChromaLocation              chroma_location;
   int64_t                       best_effort_timestamp;
   int64_t                       pkt_pos; // Deprecated
-  AVDictionary                 *metadata;
+  AVDictionary *                metadata;
 
   // Actually, there is more here, but the variables above are the only we need.
 };
 
-} // namespace ffmpeg::internal::avutil
+} // namespace libffmpeg::internal::avutil

--- a/src/lib/AVUtil/wrappers/AVMotionVectorConversion.cpp
+++ b/src/lib/AVUtil/wrappers/AVMotionVectorConversion.cpp
@@ -10,7 +10,7 @@
 
 #include <stdexcept>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 using internal::avutil::AVMotionVector_54;
@@ -73,4 +73,4 @@ parseMotionData(const LibraryVersions &libraryVersions, const uint8_t *data, con
     throw std::runtime_error("Invalid library version");
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVMotionVectorConversion.h
+++ b/src/lib/AVUtil/wrappers/AVMotionVectorConversion.h
@@ -10,7 +10,7 @@
 
 #include <vector>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 struct MotionVector
@@ -32,4 +32,4 @@ struct MotionVector
 std::vector<MotionVector>
 parseMotionData(const LibraryVersions &libraryVersions, const uint8_t *data, const size_t dataSize);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVMotionVectorConversionInternal.h
+++ b/src/lib/AVUtil/wrappers/AVMotionVectorConversionInternal.h
@@ -8,7 +8,7 @@
 
 #include <cstdint>
 
-namespace ffmpeg::internal::avutil
+namespace libffmpeg::internal::avutil
 {
 
 // This is important so that the compiler does not add padding if a struct is allocated.
@@ -38,4 +38,4 @@ struct AVMotionVector_55_56_57_58_59
 
 #pragma pack(pop)
 
-} // namespace ffmpeg::internal::avutil
+} // namespace libffmpeg::internal::avutil

--- a/src/lib/AVUtil/wrappers/AVPixFmtDescriptorConversion.cpp
+++ b/src/lib/AVUtil/wrappers/AVPixFmtDescriptorConversion.cpp
@@ -11,7 +11,7 @@
 
 using namespace std::rel_ops;
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 namespace
@@ -84,7 +84,7 @@ convertAVPixFmtDescriptor(const internal::AVPixelFormat            avPixelFormat
     format.name = std::string(p->name);
     format.numberOfComponents = static_cast<int>(p->nb_components);
     format.shiftLumaToChroma  = {static_cast<int>(p->log2_chroma_w),
-                                 static_cast<int>(p->log2_chroma_h)};
+                                static_cast<int>(p->log2_chroma_h)};
     format.flags              = parseFlagsFromValue(p->flags);
 
     for (int i = 0; i < format.numberOfComponents; ++i)
@@ -104,7 +104,7 @@ convertAVPixFmtDescriptor(const internal::AVPixelFormat            avPixelFormat
     format.name = std::string(p->name);
     format.numberOfComponents = static_cast<int>(p->nb_components);
     format.shiftLumaToChroma  = {static_cast<int>(p->log2_chroma_w),
-                                 static_cast<int>(p->log2_chroma_h)};
+                                static_cast<int>(p->log2_chroma_h)};
     format.flags              = parseFlagsFromValue(p->flags);
 
     for (int i = 0; i < format.numberOfComponents; ++i)
@@ -124,7 +124,7 @@ convertAVPixFmtDescriptor(const internal::AVPixelFormat            avPixelFormat
     format.name = std::string(p->name);
     format.numberOfComponents = static_cast<int>(p->nb_components);
     format.shiftLumaToChroma  = {static_cast<int>(p->log2_chroma_w),
-                                 static_cast<int>(p->log2_chroma_h)};
+                                static_cast<int>(p->log2_chroma_h)};
     format.flags              = parseFlagsFromValue(p->flags);
 
     for (int i = 0; i < format.numberOfComponents; ++i)
@@ -157,4 +157,4 @@ Size getSizeOfFrameComponent(const int                    component,
   return {width, height};
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVPixFmtDescriptorConversion.h
+++ b/src/lib/AVUtil/wrappers/AVPixFmtDescriptorConversion.h
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 struct PixelFormatDescriptor
@@ -80,4 +80,4 @@ Size getSizeOfFrameComponent(const int                    component,
                              const Size                   frameSize,
                              const PixelFormatDescriptor &pixelFormatDescriptor);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/src/lib/AVUtil/wrappers/AVPixFmtDescriptorConversionInternal.h
+++ b/src/lib/AVUtil/wrappers/AVPixFmtDescriptorConversionInternal.h
@@ -8,7 +8,7 @@
 
 #include <common/InternalTypes.h>
 
-namespace ffmpeg::internal::avutil
+namespace libffmpeg::internal::avutil
 {
 
 struct AVComponentDescriptor_54
@@ -22,13 +22,13 @@ struct AVComponentDescriptor_54
 
 struct AVPixFmtDescriptor_54
 {
-  const char              *name;
+  const char *             name;
   uint8_t                  nb_components;
   uint8_t                  log2_chroma_w;
   uint8_t                  log2_chroma_h;
   uint8_t                  flags;
   AVComponentDescriptor_54 comp[4];
-  const char              *alias;
+  const char *             alias;
 };
 
 struct AVComponentDescriptor_55
@@ -49,13 +49,13 @@ typedef AVComponentDescriptor_55 AVComponentDescriptor_56;
 
 struct AVPixFmtDescriptor_55
 {
-  const char              *name;
+  const char *             name;
   uint8_t                  nb_components;
   uint8_t                  log2_chroma_w;
   uint8_t                  log2_chroma_h;
   uint64_t                 flags;
   AVComponentDescriptor_55 comp[4];
-  const char              *alias;
+  const char *             alias;
 };
 
 typedef AVPixFmtDescriptor_55 AVPixFmtDescriptor_56;
@@ -71,16 +71,16 @@ struct AVComponentDescriptor_57
 
 struct AVPixFmtDescriptor_57
 {
-  const char              *name;
+  const char *             name;
   uint8_t                  nb_components;
   uint8_t                  log2_chroma_w;
   uint8_t                  log2_chroma_h;
   uint64_t                 flags;
   AVComponentDescriptor_57 comp[4];
-  const char              *alias;
+  const char *             alias;
 };
 
 typedef AVPixFmtDescriptor_57 AVPixFmtDescriptor_58;
 typedef AVPixFmtDescriptor_57 AVPixFmtDescriptor_59;
 
-} // namespace ffmpeg::internal::avutil
+} // namespace libffmpeg::internal::avutil

--- a/src/lib/Decoder.cpp
+++ b/src/lib/Decoder.cpp
@@ -9,7 +9,7 @@
 #include <common/Error.h>
 #include <common/Formatting.h>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 Decoder::Decoder(std::shared_ptr<IFFmpegLibraries> libraries)
@@ -173,4 +173,4 @@ std::optional<avutil::AVFrameWrapper> Decoder::decodeNextFrame()
   return {};
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/Decoder.h
+++ b/src/lib/Decoder.h
@@ -12,7 +12,7 @@
 #include <AVUtil/wrappers/AVFrameWrapper.h>
 #include <libHandling/IFFmpegLibraries.h>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 class Decoder
@@ -57,4 +57,4 @@ private:
   bool  flushing{};
 };
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/Demuxer.cpp
+++ b/src/lib/Demuxer.cpp
@@ -8,7 +8,7 @@
 
 #include <common/Formatting.h>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 namespace
@@ -62,4 +62,4 @@ std::optional<avcodec::AVPacketWrapper> Demuxer::getNextPacket()
   return packet;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/Demuxer.h
+++ b/src/lib/Demuxer.h
@@ -10,7 +10,7 @@
 #include <AVFormat/wrappers/AVFormatContextWrapper.h>
 #include <libHandling/IFFmpegLibraries.h>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 class Demuxer
@@ -33,4 +33,4 @@ private:
   avformat::AVFormatContextWrapper formatContext;
 };
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Error.cpp
+++ b/src/lib/common/Error.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <array>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 namespace
@@ -62,8 +62,9 @@ ReturnCode toReturnCode(const int returnValue)
 
   const auto result = std::find_if(AVERRORToReturnCodeMap.begin(),
                                    AVERRORToReturnCodeMap.end(),
-                                   [returnValue](AVErrorToReturnCode errorToReturnCode)
-                                   { return errorToReturnCode.first == returnValue; });
+                                   [returnValue](AVErrorToReturnCode errorToReturnCode) {
+                                     return errorToReturnCode.first == returnValue;
+                                   });
   if (result != AVERRORToReturnCodeMap.end())
     return result->second;
 
@@ -77,8 +78,9 @@ int toAVError(const ReturnCode returnCode)
 
   const auto result = std::find_if(AVERRORToReturnCodeMap.begin(),
                                    AVERRORToReturnCodeMap.end(),
-                                   [returnCode](AVErrorToReturnCode errorToReturnCode)
-                                   { return errorToReturnCode.second == returnCode; });
+                                   [returnCode](AVErrorToReturnCode errorToReturnCode) {
+                                     return errorToReturnCode.second == returnCode;
+                                   });
   if (result != AVERRORToReturnCodeMap.end())
     return result->first;
 
@@ -86,4 +88,4 @@ int toAVError(const ReturnCode returnCode)
   return avErrorUnknown;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Error.h
+++ b/src/lib/common/Error.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include <vector>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 enum class ReturnCode
@@ -50,4 +50,4 @@ enum class ReturnCode
 ReturnCode toReturnCode(const int returnValue);
 int        toAVError(const ReturnCode returnCode);
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Formatting.cpp
+++ b/src/lib/common/Formatting.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 std::string to_string(int64_t timestamp, Rational timebase)
@@ -107,4 +107,4 @@ std::string to_string(const LogLevel logLevel)
   }
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Formatting.h
+++ b/src/lib/common/Formatting.h
@@ -11,7 +11,7 @@
 #include <AVCodec/wrappers/AVPacketWrapper.h>
 #include <Decoder.h>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 std::string toString(int64_t timestamp, Rational timebase);
@@ -31,4 +31,4 @@ std::string to_string(const Decoder::State state);
 
 std::string to_string(const LogLevel logLevel);
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Functions.cpp
+++ b/src/lib/common/Functions.cpp
@@ -8,7 +8,7 @@
 
 #include <sstream>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Functions.h
+++ b/src/lib/common/Functions.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 inline ByteVector copyDataFromRawArray(const uint8_t *inputData, const int inputDataSize)
@@ -28,4 +28,4 @@ inline ByteVector copyDataFromRawArray(const uint8_t *inputData, const int input
   return data;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/InternalTypes.h
+++ b/src/lib/common/InternalTypes.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 
-namespace ffmpeg::internal
+namespace libffmpeg::internal
 {
 
 // Some opaque types so that we can handle pointers to them.
@@ -295,4 +295,4 @@ struct AVDictionaryEntry
   char *value;
 };
 
-} // namespace ffmpeg::internal
+} // namespace libffmpeg::internal

--- a/src/lib/common/Logging.h
+++ b/src/lib/common/Logging.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <string>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 enum class LogLevel
@@ -33,4 +33,4 @@ struct LogEntry
 
 using LoggingFunction = std::function<void(const LogLevel, const std::string &)>;
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Types.h
+++ b/src/lib/common/Types.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 struct Size
@@ -47,4 +47,4 @@ struct Rational
 using ByteVector = std::vector<std::byte>;
 using Path       = std::filesystem::path;
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Version.cpp
+++ b/src/lib/common/Version.cpp
@@ -8,7 +8,7 @@
 
 #include <sstream>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 Version Version::fromFFmpegVersion(const unsigned ffmpegVersion)
@@ -51,4 +51,4 @@ std::ostream &Version::operator<<(std::ostream &stream) const
   return stream;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/common/Version.h
+++ b/src/lib/common/Version.h
@@ -12,7 +12,7 @@
 #include <ostream>
 #include <string>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 struct Version
@@ -97,4 +97,4 @@ constexpr auto SupportedFFmpegVersions = {LibraryVersions({FFmpegVersion::FFmpeg
                                                            VersionAVUtil(54),
                                                            VersionSwresample(1)})};
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/FFmpegLibraries.cpp
+++ b/src/lib/libHandling/FFmpegLibraries.cpp
@@ -8,13 +8,13 @@
 
 #include "StaticCallbacks.h"
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 namespace
 {
 
-using AvUtilFunctions = ffmpeg::internal::functions::AvUtilFunctions;
+using AvUtilFunctions = libffmpeg::internal::functions::AvUtilFunctions;
 
 std::vector<std::string> getPossibleLibraryNames(std::string libraryName, int version)
 {
@@ -312,4 +312,4 @@ void FFmpegLibraries::disconnectAVLoggingCallback()
     unsetStaticLoggingCallback(this->avutil, this->loggingFunctionIndex.value());
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/FFmpegLibraries.h
+++ b/src/lib/libHandling/FFmpegLibraries.h
@@ -13,7 +13,7 @@
 
 #include <mutex>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 class FFmpegLibraries : public IFFmpegLibraries
@@ -65,4 +65,4 @@ private:
   friend class FFmpegLibrariesBuilder;
 };
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/FFmpegLibrariesBuilder.cpp
+++ b/src/lib/libHandling/FFmpegLibrariesBuilder.cpp
@@ -45,9 +45,14 @@ LibrariesLoadingResult FFmpegLibrariesBuilder::tryLoadingOfLibraries()
 
 #if (defined(__APPLE__) && defined(__arm64__))
   // On apple silicone, the libraries that were installed through homebrew are not automatically
-  // in the library search path. On intel, this is the case. So we will search the homebrew library
-  // path manually. Issue: https://github.com/Homebrew/brew/issues/13481
+  // in the library search path. We will search the homebrew library path manually.
+  // Issue: https://github.com/Homebrew/brew/issues/13481
   paths.push_back("/opt/homebrew/lib");
+#elif (defined(__APPLE__) && !defined(__arm64__))
+  // On macos on Intel, it can also happen that the default directory that homebrew libraries
+  // are installed in is not in the search path.
+  // https://apple.stackexchange.com/questions/40704/homebrew-installed-libraries-how-do-i-use-them
+  paths.push_back("/usr/local/lib");
 #endif
 
   for (const auto &path : paths)

--- a/src/lib/libHandling/FFmpegLibrariesBuilder.cpp
+++ b/src/lib/libHandling/FFmpegLibrariesBuilder.cpp
@@ -8,7 +8,7 @@
 
 #include "FFmpegLibraries.h"
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 LibrariesLoadingResult FFmpegLibrariesBuilder::tryLoadingOfLibraries()
@@ -86,4 +86,4 @@ FFmpegLibrariesBuilder::withLoggingFunction(const LoggingFunction loggingCallbac
   return *this;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/FFmpegLibrariesBuilder.h
+++ b/src/lib/libHandling/FFmpegLibrariesBuilder.h
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 struct LibrariesLoadingResult
@@ -41,4 +41,4 @@ private:
   LogLevel                        minimumLogLevel{LogLevel::Error};
 };
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/IFFmpegLibraries.h
+++ b/src/lib/libHandling/IFFmpegLibraries.h
@@ -17,7 +17,7 @@
 #include <filesystem>
 #include <string>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 struct LibraryInfo
@@ -43,4 +43,4 @@ public:
   internal::functions::SwResampleFunctions swresample{};
 };
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/SharedLibraryLoader.cpp
+++ b/src/lib/libHandling/SharedLibraryLoader.cpp
@@ -12,7 +12,7 @@
 #include <limits.h>
 #endif
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 namespace
@@ -148,4 +148,4 @@ void SharedLibraryLoader::updateActuallyLoadedLibraryPath(const std::string &lib
     this->libraryPath = realPath;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/SharedLibraryLoader.h
+++ b/src/lib/libHandling/SharedLibraryLoader.h
@@ -20,7 +20,7 @@
 #include <dlfcn.h>
 #endif
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 class SharedLibraryLoader
@@ -70,4 +70,4 @@ private:
   void updateActuallyLoadedLibraryPath(const std::string &libraryName);
 };
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/StaticCallbacks.cpp
+++ b/src/lib/libHandling/StaticCallbacks.cpp
@@ -9,7 +9,7 @@
 #include <array>
 #include <cstdarg>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 /* Here we store the callback functions per loaded ffmpeg library. If multiple ffmpeg libraries
@@ -117,4 +117,4 @@ void unsetStaticLoggingCallback(AvUtilFunctions &avutilFunctions, int loggingFun
       avutilFunctions.av_log_default_callback.target<void(void *, int, const char *, va_list)>());
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/StaticCallbacks.h
+++ b/src/lib/libHandling/StaticCallbacks.h
@@ -9,14 +9,14 @@
 
 #include <optional>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
-using AvUtilFunctions = ffmpeg::internal::functions::AvUtilFunctions;
+using AvUtilFunctions = libffmpeg::internal::functions::AvUtilFunctions;
 
 [[nodiscard]] std::optional<int> setStaticLoggingCallback(AvUtilFunctions &avutilFunctions,
                                                           LoggingFunction  loggingFunction);
 
 void unsetStaticLoggingCallback(AvUtilFunctions &avutilFunctions, const int loggingFunctionIndex);
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/src/lib/libHandling/libraryFunctions/AVFormatFunctions.cpp
+++ b/src/lib/libHandling/libraryFunctions/AVFormatFunctions.cpp
@@ -11,7 +11,7 @@
 
 #include "Functions.h"
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 std::optional<AvFormatFunctions> tryBindAVFormatFunctionsFromLibrary(const SharedLibraryLoader &lib,
@@ -72,4 +72,4 @@ std::optional<AvFormatFunctions> tryBindAVFormatFunctionsFromLibrary(const Share
   return functions;
 }
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/AVFormatFunctions.h
+++ b/src/lib/libHandling/libraryFunctions/AVFormatFunctions.h
@@ -11,7 +11,7 @@
 #include <common/Types.h>
 #include <libHandling/SharedLibraryLoader.h>
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 struct AvFormatFunctions
@@ -31,4 +31,4 @@ struct AvFormatFunctions
 std::optional<AvFormatFunctions> tryBindAVFormatFunctionsFromLibrary(const SharedLibraryLoader &lib,
                                                                      const LoggingFunction &log);
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/AvCodecFunctions.cpp
+++ b/src/lib/libHandling/libraryFunctions/AvCodecFunctions.cpp
@@ -9,7 +9,7 @@
 #include "Functions.h"
 #include <common/Formatting.h>
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 std::optional<AvCodecFunctions> tryBindAVCodecFunctionsFromLibrary(const SharedLibraryLoader &lib,
@@ -114,4 +114,4 @@ std::optional<AvCodecFunctions> tryBindAVCodecFunctionsFromLibrary(const SharedL
   return functions;
 }
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/AvCodecFunctions.h
+++ b/src/lib/libHandling/libraryFunctions/AvCodecFunctions.h
@@ -12,7 +12,7 @@
 #include <common/Version.h>
 #include <libHandling/SharedLibraryLoader.h>
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 struct AvCodecFunctions
@@ -47,4 +47,4 @@ std::optional<AvCodecFunctions> tryBindAVCodecFunctionsFromLibrary(const SharedL
                                                                    const Version avCodecVersion,
                                                                    const LoggingFunction &log);
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/AvUtilFunctions.cpp
+++ b/src/lib/libHandling/libraryFunctions/AvUtilFunctions.cpp
@@ -11,11 +11,11 @@
 
 #include "Functions.h"
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 std::optional<AvUtilFunctions> tryBindAVUtilFunctionsFromLibrary(const SharedLibraryLoader &lib,
-                                                                 const LoggingFunction     &log)
+                                                                 const LoggingFunction &    log)
 {
   if (!lib)
   {
@@ -90,4 +90,4 @@ std::optional<AvUtilFunctions> tryBindAVUtilFunctionsFromLibrary(const SharedLib
   return functions;
 }
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/AvUtilFunctions.h
+++ b/src/lib/libHandling/libraryFunctions/AvUtilFunctions.h
@@ -11,7 +11,7 @@
 #include <common/Types.h>
 #include <libHandling/SharedLibraryLoader.h>
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 struct AvUtilFunctions
@@ -37,6 +37,6 @@ struct AvUtilFunctions
 };
 
 std::optional<AvUtilFunctions> tryBindAVUtilFunctionsFromLibrary(const SharedLibraryLoader &lib,
-                                                                 const LoggingFunction     &log);
+                                                                 const LoggingFunction &    log);
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/Functions.cpp
+++ b/src/lib/libHandling/libraryFunctions/Functions.cpp
@@ -8,7 +8,7 @@
 
 #include <common/Formatting.h>
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 std::string logMissingFunctionsAndGetErrorMessage(const std::vector<std::string> &missingFunctions,
@@ -24,4 +24,4 @@ std::string logMissingFunctionsAndGetErrorMessage(const std::vector<std::string>
   return errorMessage;
 }
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/Functions.h
+++ b/src/lib/libHandling/libraryFunctions/Functions.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 template <typename T>
@@ -36,4 +36,4 @@ std::string logMissingFunctionsAndGetErrorMessage(const std::vector<std::string>
                                                   const std::string               libraryName,
                                                   const LoggingFunction &         log);
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/SwResampleFunctions.cpp
+++ b/src/lib/libHandling/libraryFunctions/SwResampleFunctions.cpp
@@ -10,7 +10,7 @@
 
 #include "Functions.h"
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 std::optional<SwResampleFunctions>
@@ -42,4 +42,4 @@ tryBindSwResampleFunctionsFromLibrary(const SharedLibraryLoader &lib, const Logg
   return functions;
 }
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/src/lib/libHandling/libraryFunctions/SwResampleFunctions.h
+++ b/src/lib/libHandling/libraryFunctions/SwResampleFunctions.h
@@ -10,7 +10,7 @@
 #include <common/Types.h>
 #include <libHandling/SharedLibraryLoader.h>
 
-namespace ffmpeg::internal::functions
+namespace libffmpeg::internal::functions
 {
 
 struct SwResampleFunctions
@@ -21,4 +21,4 @@ struct SwResampleFunctions
 std::optional<SwResampleFunctions>
 tryBindSwResampleFunctionsFromLibrary(const SharedLibraryLoader &lib, const LoggingFunction &log);
 
-} // namespace ffmpeg::internal::functions
+} // namespace libffmpeg::internal::functions

--- a/test/common/ComparisonFunctions.cpp
+++ b/test/common/ComparisonFunctions.cpp
@@ -8,7 +8,7 @@
 
 #include <cstddef>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 bool areEqual(const std::vector<std::string> &lhs, const std::vector<std::string> &rhs)
@@ -42,4 +42,4 @@ std::int64_t calculateFrameDataHash(const avutil::AVFrameWrapper &frame)
   return hash;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/test/common/ComparisonFunctions.h
+++ b/test/common/ComparisonFunctions.h
@@ -11,10 +11,10 @@
 #include <string>
 #include <vector>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 bool         areEqual(const std::vector<std::string> &lhs, const std::vector<std::string> &rhs);
 std::int64_t calculateFrameDataHash(const avutil::AVFrameWrapper &frame);
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/test/common/DebugFunctions.cpp
+++ b/test/common/DebugFunctions.cpp
@@ -6,7 +6,7 @@
 
 #include "DebugFunctions.h"
 
-namespace ffmpeg::test
+namespace libffmpeg::test
 {
 
 FrameFileWriter::FrameFileWriter(std::string filename)
@@ -25,4 +25,4 @@ void FrameFileWriter::write(const avutil::AVFrameWrapper &frame)
   }
 }
 
-} // namespace ffmpeg::test
+} // namespace libffmpeg::test

--- a/test/common/DebugFunctions.h
+++ b/test/common/DebugFunctions.h
@@ -10,7 +10,7 @@
 
 #include <fstream>
 
-namespace ffmpeg::test
+namespace libffmpeg::test
 {
 
 class FrameFileWriter
@@ -25,4 +25,4 @@ private:
   std::ofstream outfile;
 };
 
-} // namespace ffmpeg::test
+} // namespace libffmpeg::test

--- a/test/ffmpegTest/ffmpegTest.cpp
+++ b/test/ffmpegTest/ffmpegTest.cpp
@@ -19,11 +19,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace ffmpeg;
+using namespace libffmpeg;
 
-using ffmpeg::avutil::ColorSpace;
-using ffmpeg::avutil::MediaType;
-using ffmpeg::avutil::PictureType;
+using libffmpeg::avutil::ColorSpace;
+using libffmpeg::avutil::MediaType;
+using libffmpeg::avutil::PictureType;
 using ::testing::Contains;
 
 namespace

--- a/test/unit/libHandling/FFmpegLibrariesMoc.cpp
+++ b/test/unit/libHandling/FFmpegLibrariesMoc.cpp
@@ -6,7 +6,7 @@
 
 #include "FFmpegLibrariesMoc.h"
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 using internal::AVCodec;
@@ -233,4 +233,4 @@ int FFmpegLibrariesMock::avcodec_open2_mock(internal::AVCodecContext *codecConte
   return 0;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/test/unit/libHandling/FFmpegLibrariesMoc.h
+++ b/test/unit/libHandling/FFmpegLibrariesMoc.h
@@ -11,7 +11,7 @@
 
 #include <gmock/gmock.h>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 struct AVDummy
@@ -95,4 +95,4 @@ private:
                           internal::AVDictionary **);
 };
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/test/unit/libHandling/SharedLibraryLoaderTest.cpp
+++ b/test/unit/libHandling/SharedLibraryLoaderTest.cpp
@@ -10,7 +10,7 @@
 
 TEST(SharedLibraryLoader, DefaultValuesTest)
 {
-  ffmpeg::SharedLibraryLoader loader;
+  libffmpeg::SharedLibraryLoader loader;
 
   EXPECT_FALSE(loader.isLoaded());
   EXPECT_TRUE(loader.getLibraryPath().empty());
@@ -26,7 +26,7 @@ TEST(SharedLibraryLoader, DefaultValuesTest)
 
 TEST(SharedLibraryLoader, OpenDummyLibrary)
 {
-  ffmpeg::SharedLibraryLoader loader;
+  libffmpeg::SharedLibraryLoader loader;
 
   const auto debugPath = std::filesystem::current_path();
 

--- a/test/unit/wrappers/AVCodec/AVCodecContextWrapperTest.cpp
+++ b/test/unit/wrappers/AVCodec/AVCodecContextWrapperTest.cpp
@@ -17,18 +17,18 @@
 
 #include <array>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
-using ffmpeg::internal::AVCodec;
-using ffmpeg::internal::AVCodecContext;
-using ffmpeg::internal::AVCodecID;
-using ffmpeg::internal::AVCodecParameters;
-using ffmpeg::internal::AVColorSpace;
-using ffmpeg::internal::AVFrame;
-using ffmpeg::internal::AVPacket;
-using ffmpeg::internal::AVPixelFormat;
-using ffmpeg::internal::AVRational;
+using libffmpeg::internal::AVCodec;
+using libffmpeg::internal::AVCodecContext;
+using libffmpeg::internal::AVCodecID;
+using libffmpeg::internal::AVCodecParameters;
+using libffmpeg::internal::AVColorSpace;
+using libffmpeg::internal::AVFrame;
+using libffmpeg::internal::AVPacket;
+using libffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVRational;
 using ::testing::NiceMock;
 using ::testing::Return;
 
@@ -46,7 +46,7 @@ template <FFmpegVersion V> void runAVCodecContextTest()
   ffmpegLibraries->functionChecks.avutilPixFmtDescGetExpectedFormat = TEST_PIXEL_FORMAT;
 
   AVCodecContextType<V> codecContext;
-  codecContext.codec_type = ffmpeg::internal::AVMEDIA_TYPE_ATTACHMENT;
+  codecContext.codec_type = libffmpeg::internal::AVMEDIA_TYPE_ATTACHMENT;
   codecContext.codec_id   = TEST_CODEC_ID;
   codecContext.pix_fmt    = TEST_PIXEL_FORMAT;
   codecContext.width      = TEST_WIDTH;
@@ -156,4 +156,4 @@ INSTANTIATE_TEST_SUITE_P(AVCodecContextWrapper,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/test/unit/wrappers/AVCodec/AVCodecDescriptorConversionTest.cpp
+++ b/test/unit/wrappers/AVCodec/AVCodecDescriptorConversionTest.cpp
@@ -14,11 +14,11 @@
 
 #include <array>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
-using ffmpeg::internal::AVCodecDescriptor;
-using ffmpeg::internal::AVCodecID;
+using libffmpeg::internal::AVCodecDescriptor;
+using libffmpeg::internal::AVCodecID;
 
 namespace
 {
@@ -44,7 +44,7 @@ template <FFmpegVersion V> void runParsingTest()
 {
   AVCodecDescriptorType<V> rawDescriptor;
   rawDescriptor.id        = static_cast<AVCodecID>(37);
-  rawDescriptor.type      = ffmpeg::internal::AVMEDIA_TYPE_VIDEO;
+  rawDescriptor.type      = libffmpeg::internal::AVMEDIA_TYPE_VIDEO;
   rawDescriptor.name      = TEST_NAME;
   rawDescriptor.long_name = TEST_LONG_NAME;
 
@@ -55,7 +55,7 @@ template <FFmpegVersion V> void runParsingTest()
   const std::array<const char *, 4> MIME_TYPES = {"MimeType0", "MimeType1", "MimeType2", nullptr};
   rawDescriptor.mime_types                     = MIME_TYPES.data();
 
-  std::array<ffmpeg::internal::avcodec::AVProfile_57, 4> profiles;
+  std::array<libffmpeg::internal::avcodec::AVProfile_57, 4> profiles;
   const std::array<const char *, 4>                      PROFILE_NAMES = {
       "ProfileName0", "ProfileName1", "ProfileName2", "TerminatingProfile"};
   constexpr auto FF_PROFILE_UNKNOWN = -99;
@@ -107,4 +107,4 @@ INSTANTIATE_TEST_SUITE_P(AVCodecWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/test/unit/wrappers/AVCodec/AVCodecParametersWrapperTest.cpp
+++ b/test/unit/wrappers/AVCodec/AVCodecParametersWrapperTest.cpp
@@ -17,19 +17,19 @@
 
 #include <array>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVCodecID;
-using ffmpeg::internal::AVCodecParameters;
-using ffmpeg::internal::AVCOL_SPC_SMPTE240M;
-using ffmpeg::internal::AVMEDIA_TYPE_AUDIO;
-using ffmpeg::internal::AVPixelFormat;
-using ffmpeg::internal::AVPixFmtDescriptor;
-using ffmpeg::internal::AVRational;
+using libffmpeg::internal::AVCodecID;
+using libffmpeg::internal::AVCodecParameters;
+using libffmpeg::internal::AVCOL_SPC_SMPTE240M;
+using libffmpeg::internal::AVMEDIA_TYPE_AUDIO;
+using libffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVPixFmtDescriptor;
+using libffmpeg::internal::AVRational;
 using ::testing::Return;
 
 void runAVCodecParametersWrapperTestAVFormat56(const LibraryVersions &version)
@@ -38,12 +38,12 @@ void runAVCodecParametersWrapperTestAVFormat56(const LibraryVersions &version)
   auto ffmpegLibraries = std::make_shared<FFmpegLibrariesMock>();
   EXPECT_CALL(*ffmpegLibraries, getLibrariesVersion()).WillRepeatedly(Return(version));
 
-  ffmpeg::internal::avcodec::AVCodecParameters_56 codecParameters;
+  libffmpeg::internal::avcodec::AVCodecParameters_56 codecParameters;
   AVCodecParametersWrapper parameters(reinterpret_cast<AVCodecParameters *>(&codecParameters),
                                       ffmpegLibraries);
 
   EXPECT_EQ(parameters.getCodecType(), avutil::MediaType::Unknown);
-  EXPECT_EQ(parameters.getCodecID(), ffmpeg::internal::AV_CODEC_ID_NONE);
+  EXPECT_EQ(parameters.getCodecID(), libffmpeg::internal::AV_CODEC_ID_NONE);
   EXPECT_TRUE(parameters.getExtradata().empty());
   EXPECT_EQ(parameters.getSize(), Size());
   EXPECT_EQ(parameters.getColorspace(), avutil::ColorSpace::UNSPECIFIED);
@@ -130,4 +130,4 @@ INSTANTIATE_TEST_SUITE_P(AVFormatWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/test/unit/wrappers/AVCodec/AVCodecWrapperTest.cpp
+++ b/test/unit/wrappers/AVCodec/AVCodecWrapperTest.cpp
@@ -16,15 +16,15 @@
 
 #include <array>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVCodec;
-using ffmpeg::internal::AVPixelFormat;
-using ffmpeg::internal::AVRational;
+using libffmpeg::internal::AVCodec;
+using libffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVRational;
 using ::testing::Return;
 
 template <FFmpegVersion V> void runAVCodecWrapperTest()
@@ -40,7 +40,7 @@ template <FFmpegVersion V> void runAVCodecWrapperTest()
   AVCodecType<V> rawCodec;
   rawCodec.name         = TEST_NAME;
   rawCodec.long_name    = TEST_LONG_NAME;
-  rawCodec.type         = ffmpeg::internal::AVMEDIA_TYPE_SUBTITLE;
+  rawCodec.type         = libffmpeg::internal::AVMEDIA_TYPE_SUBTITLE;
   rawCodec.id           = TEST_CODEC_ID;
   rawCodec.capabilities = TEST_CAPABILITIES;
 
@@ -105,4 +105,4 @@ INSTANTIATE_TEST_SUITE_P(AVCodecWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/test/unit/wrappers/AVCodec/AVPacketWrapperTest.cpp
+++ b/test/unit/wrappers/AVCodec/AVPacketWrapperTest.cpp
@@ -15,13 +15,13 @@
 
 #include <array>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVPacket;
+using libffmpeg::internal::AVPacket;
 using ::testing::NiceMock;
 using ::testing::Return;
 
@@ -54,7 +54,7 @@ public:
     this->avcodec.av_new_packet   = [this](AVPacket *packet, int dataSize) {
       return this->newPacket(packet, dataSize);
     };
-    if constexpr (std::is_same_v<AVPacketType, ffmpeg::internal::avcodec::AVPacket_56>)
+    if constexpr (std::is_same_v<AVPacketType, libffmpeg::internal::avcodec::AVPacket_56>)
     {
       this->avcodec.av_init_packet = [this](AVPacket *packet) { this->initPacket(packet); };
       this->avcodec.av_free_packet = [this](AVPacket *packet) { this->freePacket(packet); };
@@ -112,7 +112,7 @@ public:
   // AVCodec major version 56 only
   void initPacket(AVPacket *packet)
   {
-    auto castPacket          = reinterpret_cast<ffmpeg::internal::avcodec::AVPacket_56 *>(packet);
+    auto castPacket          = reinterpret_cast<libffmpeg::internal::avcodec::AVPacket_56 *>(packet);
     castPacket->stream_index = TEST_STREAM_INDEX;
     castPacket->pts          = TEST_PTS;
     castPacket->dts          = TEST_DTS;
@@ -271,4 +271,4 @@ INSTANTIATE_TEST_SUITE_P(AVCodecWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/test/unit/wrappers/AVCodec/VersionToAVCodecTypes.h
+++ b/test/unit/wrappers/AVCodec/VersionToAVCodecTypes.h
@@ -13,7 +13,7 @@
 #include <AVCodec/wrappers/AVPacketWrapperInternal.h>
 #include <wrappers/RunTestForAllVersions.h>
 
-namespace ffmpeg::avcodec
+namespace libffmpeg::avcodec
 {
 
 namespace
@@ -75,4 +75,4 @@ template <FFmpegVersion V> constexpr auto avCodecDescriptorTypeFunction()
 template <FFmpegVersion V>
 using AVCodecDescriptorType = typename decltype(avCodecDescriptorTypeFunction<V>())::type;
 
-} // namespace ffmpeg::avcodec
+} // namespace libffmpeg::avcodec

--- a/test/unit/wrappers/AVFormat/AVFormatContextWrapperTest.cpp
+++ b/test/unit/wrappers/AVFormat/AVFormatContextWrapperTest.cpp
@@ -16,19 +16,19 @@
 
 #include <gtest/gtest.h>
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 namespace
 {
 
-using ffmpeg::avcodec::AVPacketType;
-using ffmpeg::internal::AVDictionary;
-using ffmpeg::internal::AVDictionaryEntry;
-using ffmpeg::internal::AVFormatContext;
-using ffmpeg::internal::AVInputFormat;
-using ffmpeg::internal::AVPacket;
-using ffmpeg::internal::AVStream;
+using libffmpeg::avcodec::AVPacketType;
+using libffmpeg::internal::AVDictionary;
+using libffmpeg::internal::AVDictionaryEntry;
+using libffmpeg::internal::AVFormatContext;
+using libffmpeg::internal::AVInputFormat;
+using libffmpeg::internal::AVPacket;
+using libffmpeg::internal::AVStream;
 using ::testing::Return;
 
 constexpr auto TEST_START_TIME          = 483;
@@ -224,4 +224,4 @@ INSTANTIATE_TEST_SUITE_P(AVFormatWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/test/unit/wrappers/AVFormat/AVInputFormatWrapperTest.cpp
+++ b/test/unit/wrappers/AVFormat/AVInputFormatWrapperTest.cpp
@@ -13,13 +13,13 @@
 
 #include <gtest/gtest.h>
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVInputFormat;
+using libffmpeg::internal::AVInputFormat;
 using ::testing::Return;
 
 template <FFmpegVersion V> void runAVInputFormatWrapperTest()
@@ -100,4 +100,4 @@ INSTANTIATE_TEST_SUITE_P(AVFormatWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/test/unit/wrappers/AVFormat/AVStreamWrapperTest.cpp
+++ b/test/unit/wrappers/AVFormat/AVStreamWrapperTest.cpp
@@ -16,21 +16,21 @@
 
 #include <array>
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVCodecContext;
-using ffmpeg::internal::AVCodecDescriptor;
-using ffmpeg::internal::AVCodecID;
-using ffmpeg::internal::AVCodecParameters;
-using ffmpeg::internal::AVCOL_SPC_FCC;
-using ffmpeg::internal::AVMEDIA_TYPE_AUDIO;
-using ffmpeg::internal::AVPixelFormat;
-using ffmpeg::internal::AVRational;
-using ffmpeg::internal::AVStream;
+using libffmpeg::internal::AVCodecContext;
+using libffmpeg::internal::AVCodecDescriptor;
+using libffmpeg::internal::AVCodecID;
+using libffmpeg::internal::AVCodecParameters;
+using libffmpeg::internal::AVCOL_SPC_FCC;
+using libffmpeg::internal::AVMEDIA_TYPE_AUDIO;
+using libffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVRational;
+using libffmpeg::internal::AVStream;
 using ::testing::Return;
 
 constexpr auto TEST_CODEC_ID = internal::AV_CODEC_ID_TESTING;
@@ -41,14 +41,14 @@ template <FFmpegVersion V> void runAVStreamWrapperTestDefaultValues()
   EXPECT_CALL(*ffmpegLibraries, getLibrariesVersion()).WillRepeatedly(Return(getLibraryVerions(V)));
 
   ffmpegLibraries->functionChecks.avcodecDescriptorGetExpectedID =
-      ffmpeg::internal::AV_CODEC_ID_NONE;
+      libffmpeg::internal::AV_CODEC_ID_NONE;
 
   AVStreamType<V> stream;
   AVStreamWrapper streamWrapper(reinterpret_cast<AVStream *>(&stream), ffmpegLibraries);
 
   EXPECT_EQ(streamWrapper.getIndex(), 0);
   EXPECT_EQ(streamWrapper.getCodecType(), avutil::MediaType::Unknown);
-  EXPECT_EQ(streamWrapper.getCodecID(), ffmpeg::internal::AV_CODEC_ID_NONE);
+  EXPECT_EQ(streamWrapper.getCodecID(), libffmpeg::internal::AV_CODEC_ID_NONE);
   EXPECT_EQ(streamWrapper.getAverageFrameRate(), Rational({0, 0}));
   EXPECT_EQ(streamWrapper.getTimeBase(), Rational({0, 0}));
   EXPECT_EQ(streamWrapper.getFrameSize(), Size());
@@ -221,4 +221,4 @@ INSTANTIATE_TEST_SUITE_P(AVFormatWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/test/unit/wrappers/AVFormat/VersionToAVFormatTypes.h
+++ b/test/unit/wrappers/AVFormat/VersionToAVFormatTypes.h
@@ -11,7 +11,7 @@
 #include <AVFormat/wrappers/AVStreamWrapperInternal.h>
 #include <wrappers/RunTestForAllVersions.h>
 
-namespace ffmpeg::avformat
+namespace libffmpeg::avformat
 {
 
 namespace
@@ -56,4 +56,4 @@ template <FFmpegVersion V> constexpr auto avFormatContextTypeFunction()
 template <FFmpegVersion V>
 using AVFormatContextType = typename decltype(avFormatContextTypeFunction<V>())::type;
 
-} // namespace ffmpeg::avformat
+} // namespace libffmpeg::avformat

--- a/test/unit/wrappers/AVUtil/AVDictionaryWrapperTest.cpp
+++ b/test/unit/wrappers/AVUtil/AVDictionaryWrapperTest.cpp
@@ -12,11 +12,11 @@
 
 #include <array>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
-using ffmpeg::internal::AVDictionary;
-using ffmpeg::internal::AVDictionaryEntry;
+using libffmpeg::internal::AVDictionary;
+using libffmpeg::internal::AVDictionaryEntry;
 using StringPair = std::pair<std::string, std::string>;
 
 TEST(AVDictionaryWrapperTest, NullptrShouldReturnEmptyMap)
@@ -63,4 +63,4 @@ TEST(AVDictionaryWrapperTest, GetDictEntriesTest)
   EXPECT_EQ(ffmpegLibraries->functionCounters.avDictGet, 5);
 }
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/test/unit/wrappers/AVUtil/AVFrameSideDataWrapperTest.cpp
+++ b/test/unit/wrappers/AVUtil/AVFrameSideDataWrapperTest.cpp
@@ -14,15 +14,15 @@
 
 #include <array>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 namespace
 {
 
-using ffmpeg::internal::AV_FRAME_DATA_DOWNMIX_INFO;
-using ffmpeg::internal::AV_FRAME_DATA_MOTION_VECTORS;
-using ffmpeg::internal::AVFrameSideData;
+using libffmpeg::internal::AV_FRAME_DATA_DOWNMIX_INFO;
+using libffmpeg::internal::AV_FRAME_DATA_MOTION_VECTORS;
+using libffmpeg::internal::AVFrameSideData;
 using internal::avutil::AVMotionVector_54;
 using internal::avutil::AVMotionVector_55_56_57_58_59;
 
@@ -141,4 +141,4 @@ INSTANTIATE_TEST_SUITE_P(AVUtilWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/test/unit/wrappers/AVUtil/AVFrameWrapperTest.cpp
+++ b/test/unit/wrappers/AVUtil/AVFrameWrapperTest.cpp
@@ -13,14 +13,14 @@
 
 #include <gtest/gtest.h>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVFrame;
-using ffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVFrame;
+using libffmpeg::internal::AVPixelFormat;
 
 using ::testing::Return;
 
@@ -128,4 +128,4 @@ INSTANTIATE_TEST_SUITE_P(AVUtilWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/test/unit/wrappers/AVUtil/AVPixFmtDescriptorConversionTest.cpp
+++ b/test/unit/wrappers/AVUtil/AVPixFmtDescriptorConversionTest.cpp
@@ -14,14 +14,14 @@
 
 #include <gtest/gtest.h>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 namespace
 {
 
-using ffmpeg::internal::AVPixelFormat;
-using ffmpeg::internal::AVPixFmtDescriptor;
+using libffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVPixFmtDescriptor;
 
 using ::testing::Return;
 
@@ -125,4 +125,4 @@ INSTANTIATE_TEST_SUITE_P(AVUtilWrappers,
                          testing::ValuesIn(SupportedFFmpegVersions),
                          getNameWithFFmpegVersion);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/test/unit/wrappers/AVUtil/AVPixFmtDescriptorCreation.cpp
+++ b/test/unit/wrappers/AVUtil/AVPixFmtDescriptorCreation.cpp
@@ -7,18 +7,18 @@
 #include "AVPixFmtDescriptorCreation.h"
 #include <AVUtil/wrappers/AVPixFmtDescriptorConversionInternal.h>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
-using ffmpeg::internal::avutil::AVComponentDescriptor_54;
-using ffmpeg::internal::avutil::AVComponentDescriptor_55;
-using ffmpeg::internal::avutil::AVComponentDescriptor_56;
-using ffmpeg::internal::avutil::AVComponentDescriptor_57;
-using ffmpeg::internal::avutil::AVPixFmtDescriptor_54;
-using ffmpeg::internal::avutil::AVPixFmtDescriptor_55;
-using ffmpeg::internal::avutil::AVPixFmtDescriptor_56;
-using ffmpeg::internal::avutil::AVPixFmtDescriptor_57;
-using ffmpeg::internal::avutil::AVPixFmtDescriptor_58;
+using libffmpeg::internal::avutil::AVComponentDescriptor_54;
+using libffmpeg::internal::avutil::AVComponentDescriptor_55;
+using libffmpeg::internal::avutil::AVComponentDescriptor_56;
+using libffmpeg::internal::avutil::AVComponentDescriptor_57;
+using libffmpeg::internal::avutil::AVPixFmtDescriptor_54;
+using libffmpeg::internal::avutil::AVPixFmtDescriptor_55;
+using libffmpeg::internal::avutil::AVPixFmtDescriptor_56;
+using libffmpeg::internal::avutil::AVPixFmtDescriptor_57;
+using libffmpeg::internal::avutil::AVPixFmtDescriptor_58;
 
 namespace
 {
@@ -74,4 +74,4 @@ createRawFormatDescriptor<AVPixFmtDescriptor_55>(const PixelFormatDescriptor &pi
 template AVPixFmtDescriptor_57
 createRawFormatDescriptor<AVPixFmtDescriptor_57>(const PixelFormatDescriptor &pixelFormat);
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/test/unit/wrappers/AVUtil/AVPixFmtDescriptorCreation.h
+++ b/test/unit/wrappers/AVUtil/AVPixFmtDescriptorCreation.h
@@ -9,9 +9,9 @@
 #include <AVUtil/wrappers/AVPixFmtDescriptorConversion.h>
 #include <common/InternalTypes.h>
 
-using ffmpeg::internal::AVPixelFormat;
+using libffmpeg::internal::AVPixelFormat;
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 template <typename AVPixFmtDescriptorType>

--- a/test/unit/wrappers/AVUtil/VersionToAVUtilTypes.h
+++ b/test/unit/wrappers/AVUtil/VersionToAVUtilTypes.h
@@ -13,7 +13,7 @@
 #include <AVUtil/wrappers/AVMotionVectorConversionInternal.h>
 #include <AVUtil/wrappers/AVPixFmtDescriptorConversionInternal.h>
 
-namespace ffmpeg::avutil
+namespace libffmpeg::avutil
 {
 
 namespace
@@ -70,4 +70,4 @@ template <FFmpegVersion V> constexpr auto avFrameFromVersionFunc()
 
 template <FFmpegVersion V> using AVFrameType = typename decltype(avFrameFromVersionFunc<V>())::type;
 
-} // namespace ffmpeg::avutil
+} // namespace libffmpeg::avutil

--- a/test/unit/wrappers/RunTestForAllVersions.h
+++ b/test/unit/wrappers/RunTestForAllVersions.h
@@ -8,21 +8,21 @@
 
 #include <common/Version.h>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 #define RUN_TEST_FOR_VERSION(version, testFunctionName)                                            \
   {                                                                                                \
-    if (version.ffmpegVersion == ffmpeg::FFmpegVersion::FFmpeg_2x)                                 \
-      testFunctionName<ffmpeg::FFmpegVersion::FFmpeg_2x>();                                        \
-    else if (version.ffmpegVersion == ffmpeg::FFmpegVersion::FFmpeg_3x)                            \
-      testFunctionName<ffmpeg::FFmpegVersion::FFmpeg_3x>();                                        \
-    else if (version.ffmpegVersion == ffmpeg::FFmpegVersion::FFmpeg_4x)                            \
-      testFunctionName<ffmpeg::FFmpegVersion::FFmpeg_4x>();                                        \
-    else if (version.ffmpegVersion == ffmpeg::FFmpegVersion::FFmpeg_5x)                            \
-      testFunctionName<ffmpeg::FFmpegVersion::FFmpeg_5x>();                                        \
-    else if (version.ffmpegVersion == ffmpeg::FFmpegVersion::FFmpeg_6x)                            \
-      testFunctionName<ffmpeg::FFmpegVersion::FFmpeg_6x>();                                        \
+    if (version.ffmpegVersion == libffmpeg::FFmpegVersion::FFmpeg_2x)                                 \
+      testFunctionName<libffmpeg::FFmpegVersion::FFmpeg_2x>();                                        \
+    else if (version.ffmpegVersion == libffmpeg::FFmpegVersion::FFmpeg_3x)                            \
+      testFunctionName<libffmpeg::FFmpegVersion::FFmpeg_3x>();                                        \
+    else if (version.ffmpegVersion == libffmpeg::FFmpegVersion::FFmpeg_4x)                            \
+      testFunctionName<libffmpeg::FFmpegVersion::FFmpeg_4x>();                                        \
+    else if (version.ffmpegVersion == libffmpeg::FFmpegVersion::FFmpeg_5x)                            \
+      testFunctionName<libffmpeg::FFmpegVersion::FFmpeg_5x>();                                        \
+    else if (version.ffmpegVersion == libffmpeg::FFmpegVersion::FFmpeg_6x)                            \
+      testFunctionName<libffmpeg::FFmpegVersion::FFmpeg_6x>();                                        \
   }
 
 template <typename T> struct TypeWrapper
@@ -44,4 +44,4 @@ constexpr LibraryVersions getLibraryVerions(const FFmpegVersion ffmpegVersion)
   return {};
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg

--- a/test/unit/wrappers/TestHelper.h
+++ b/test/unit/wrappers/TestHelper.h
@@ -13,7 +13,7 @@
 
 #include <gtest/gtest.h>
 
-namespace ffmpeg
+namespace libffmpeg
 {
 
 static std::string getNameWithFFmpegVersion(const testing::TestParamInfo<LibraryVersions> &info)
@@ -44,4 +44,4 @@ template <typename Iter> std::vector<Rational> toRationalVector(Iter begin, Iter
   return rationals;
 }
 
-} // namespace ffmpeg
+} // namespace libffmpeg


### PR DESCRIPTION
Rename namespace from ffmpeg (which I think is a bit to vague and could easily collide with other namespaces) to `libffmpeg`